### PR TITLE
Experimental Drop Menu On All Pages

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -41,7 +41,7 @@ class MainScreen extends StatelessWidget {
       return SpeedDial(
         animatedIcon: AnimatedIcons.menu_close,
         animatedIconTheme: const IconThemeData(size: 20.0),
-        label: const Text('Jump To'),
+        label: const Text('Jump Ahead'),
         children: [
           SpeedDialChild(
             child: const Icon(Icons.book, color: Colors.black),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,6 +3,7 @@ import '/Musical-Terms/Musical-Terms.dart';
 import '/Composers/Composers.dart';
 import '/Musical-Works/Musical-Works.dart';
 import '/Quizzes/Quizzes.dart';
+import 'package:flutter_speed_dial/flutter_speed_dial.dart';
 
 void main() {
   runApp(
@@ -28,61 +29,123 @@ void main() {
 
 class MainScreen extends StatelessWidget {
   const MainScreen({super.key});
+  // Globally changes the strength/contrast of a color for an icon
+  final int iconColor = 100;
 
   @override
   Widget build(BuildContext context) {
     final ButtonStyle style =
-    ElevatedButton.styleFrom(textStyle: const TextStyle(fontSize: 20));
-    return Scaffold(
-        appBar: AppBar(
-          title: const Text('Home Page'),
-        ),
-        body: Center(
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: <Widget>[
-              ElevatedButton(
-                style: style,
-                onPressed: () {
-                  Navigator.pushNamed(context, '/terms');
-                },
-                child: const Text('Terms'),
-              ),
-              const SizedBox(height: 30),
-              ElevatedButton(
-                style: style,
-                onPressed: () {
-                  Navigator.pushNamed(context, '/composers');
-                },
-                child: const Text('Composers'),
-              ),
-              const SizedBox(height: 30),
-              ElevatedButton(
-                style: style,
-                onPressed: () {
-                  Navigator.pushNamed(context, '/works');
-                },
-                child: const Text('Works'),
-              ),
-              const SizedBox(height: 30),
-              ElevatedButton(
-                style: style,
-                onPressed: () {
-                  Navigator.pushNamed(context, '/quizzes');
-                },
-                child: const Text('Quizzes'),
-              ),
-              const SizedBox(height: 30),
-              ElevatedButton(
-                style: style,
-                onPressed: () {
-                  Navigator.pushNamed(context, '/listen');
-                },
-                child: const Text('Listen'),
-              ),
-            ],
+        ElevatedButton.styleFrom(textStyle: const TextStyle(fontSize: 20));
+
+    SpeedDial buildSpeedDialMainMenu() {
+      return SpeedDial(
+        animatedIcon: AnimatedIcons.menu_close,
+        animatedIconTheme: const IconThemeData(size: 20.0),
+        label: const Text('Jump To'),
+        children: [
+          SpeedDialChild(
+            child: const Icon(Icons.book, color: Colors.black),
+            backgroundColor: Colors.red[iconColor],
+            onTap: () => Navigator.pushNamed(context, '/terms'),
+            label: 'Musical Terms',
+            labelStyle: const TextStyle(
+                fontWeight: FontWeight.w500, color: Colors.white),
+            labelBackgroundColor: Colors.black,
           ),
-        ));
+          SpeedDialChild(
+            child: const Icon(Icons.quiz, color: Colors.black),
+            backgroundColor: Colors.green[iconColor],
+            onTap: () => Navigator.pushNamed(context, '/quizzes'),
+            label: 'Quizzes',
+            labelStyle: const TextStyle(
+                fontWeight: FontWeight.w500, color: Colors.white),
+            labelBackgroundColor: Colors.black,
+          ),
+          SpeedDialChild(
+            child: const Icon(Icons.music_note, color: Colors.black),
+            backgroundColor: Colors.blue[iconColor],
+            onTap: () => Navigator.pushNamed(context, '/works'),
+            label: 'Music',
+            labelStyle: const TextStyle(
+                fontWeight: FontWeight.w500, color: Colors.white),
+            labelBackgroundColor: Colors.black,
+          ),
+          SpeedDialChild(
+            child: const Icon(Icons.person, color: Colors.black),
+            backgroundColor: Colors.yellow[iconColor],
+            onTap: () => Navigator.pushNamed(context, '/composers'),
+            label: 'Composers',
+            labelStyle: const TextStyle(
+                fontWeight: FontWeight.w500, color: Colors.white),
+            labelBackgroundColor: Colors.black,
+          ),
+        ],
+      );
+    }
+
+    Widget buildBottomButtonMainMenuSection = Row(
+      children: [
+        Expanded(
+          child: Container(
+            alignment: Alignment.bottomRight,
+              padding: const EdgeInsets.all(10.0),
+              child: buildSpeedDialMainMenu()),
+        ),
+      ],
+    );
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Home Page'),
+      ),
+      body: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            ElevatedButton(
+              style: style,
+              onPressed: () {
+                Navigator.pushNamed(context, '/terms');
+              },
+              child: const Text('Terms'),
+            ),
+            const SizedBox(height: 30),
+            ElevatedButton(
+              style: style,
+              onPressed: () {
+                Navigator.pushNamed(context, '/composers');
+              },
+              child: const Text('Composers'),
+            ),
+            const SizedBox(height: 30),
+            ElevatedButton(
+              style: style,
+              onPressed: () {
+                Navigator.pushNamed(context, '/works');
+              },
+              child: const Text('Works'),
+            ),
+            const SizedBox(height: 30),
+            ElevatedButton(
+              style: style,
+              onPressed: () {
+                Navigator.pushNamed(context, '/quizzes');
+              },
+              child: const Text('Quizzes'),
+            ),
+            const SizedBox(height: 30),
+            ElevatedButton(
+              style: style,
+              onPressed: () {
+                Navigator.pushNamed(context, '/listen');
+              },
+              child: const Text('Listen'),
+            ),
+            buildBottomButtonMainMenuSection
+          ],
+        ),
+      ),
+    );
   }
 }
 
@@ -92,7 +155,7 @@ class ListenScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final ButtonStyle style =
-    ElevatedButton.styleFrom(textStyle: const TextStyle(fontSize: 20));
+        ElevatedButton.styleFrom(textStyle: const TextStyle(fontSize: 20));
     return Scaffold(
         appBar: AppBar(
           title: const Text('Listen'),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -62,6 +62,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.1"
+  flutter_speed_dial:
+    dependency: "direct main"
+    description:
+      name: flutter_speed_dial
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "6.2.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -158,3 +165,4 @@ packages:
     version: "2.1.2"
 sdks:
   dart: ">=2.18.5 <3.0.0"
+  flutter: ">=2.5.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,6 +36,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
+  flutter_speed_dial: ^6.2.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
The drop down menu (speed dial) that Richard is working on for the main menu has been applied to the four other screens with buttons allowing for traversal to the other three screens as well as back to the main menu. This is not final as far as matching Richard's final design decision, and this is far from final as far as our final design. This is simply "basic navigation between pages" for developmental purposes.