### PR TITLE
Add back button to Terms menu

### DIFF
--- a/lib/Musical-Terms/Definition-Page.dart
+++ b/lib/Musical-Terms/Definition-Page.dart
@@ -19,7 +19,7 @@ class DefScreen extends StatelessWidget {
       body: SafeArea(
         child: Column(children: <Widget>[
           const Align(
-            alignment: Alignment.bottomLeft,
+            alignment: Alignment.topLeft,
             child: BackButton(),
           ),
           Center(

--- a/lib/Musical-Terms/Musical-Terms.dart
+++ b/lib/Musical-Terms/Musical-Terms.dart
@@ -28,7 +28,12 @@ class TermsScreenState extends State<TermsScreen> {
 
     return Scaffold(
         body: SafeArea(
-          child: Center(
+            child: Column(children: <Widget>[
+          const Align(
+            alignment: Alignment.topLeft,
+            child: BackButton(),
+          ),
+          Center(
               child: Column(
             mainAxisSize: MainAxisSize.min,
             children: <Widget>[
@@ -75,7 +80,7 @@ class TermsScreenState extends State<TermsScreen> {
                   }),
             ],
           )),
-        ),
+        ])),
         floatingActionButtonLocation: FloatingActionButtonLocation.centerDocked,
         floatingActionButton: CircularDialMenu.build(context),
         bottomNavigationBar: BottomAppBar(


### PR DESCRIPTION
<!-- Feel free to use it and tweak some parts -->

#### Description
<!-- A general summary of your changes -->
Adds a back button to the terms menu.

#### Screenshots (if appropriate):
<!-- Feel free to delete this if not used -->
<img width="284" alt="Screenshot 2023-02-17 113342" src="https://user-images.githubusercontent.com/114765511/219710958-9ee133e3-1c3a-4aee-898e-90cafcd92ab5.png">


#### Types of Changes
<!-- Feel free to remove the ones you don't use, or remove all of them and explain what type of change it is -->
- Bug fix (non-breaking change which fixes an issue)

#### Notes
<!-- Extra things you want to include -->
Also makes the back button on the Definitions page topLeft aligned instead of bottomLeft, which is more intuitive.

#### Checklist
<!-- Some reminders -->
- [ ] Moved the task in [Jira](https://jib-2329.atlassian.net/jira/software/projects/OM2329/boards/1) to 'In Review'
- [ ] Updated the Incremental Release Notes
