### PR TITLE
Adds support for quizzes

### DIFF
--- a/lib/Quizzes/QuestionSemantics/TF_question.dart
+++ b/lib/Quizzes/QuestionSemantics/TF_question.dart
@@ -1,0 +1,65 @@
+import 'package:artifact/Quizzes/QuestionSemantics/quiz_question.dart';
+import 'package:artifact/Quizzes/quiz.dart';
+import 'package:flutter/material.dart';
+
+
+class TFQuestion extends QuizQuestion {
+  String question;
+  String correctAnswer;
+
+  TFQuestion({required this.question,
+    required this.correctAnswer,});
+
+  static TextButton getButton(String text, Function onPressed) {
+    return TextButton(
+      onPressed: () => {
+        onPressed(text)
+      },
+      style: ButtonStyle(
+          backgroundColor: MaterialStateProperty.all(Colors.blueGrey[100])),
+      child: Text(text, style: const TextStyle(color: Colors.black)),
+    );
+  }
+
+  @override
+  Widget display({required Quiz quiz,
+    int qNum = 0,
+    required BuildContext context,
+    required Function onPressed,}) {
+    List<String> questions = ['True', 'False'];
+    List<Widget> answerButtons = [];
+    for (int i = 0; i < questions.length; i++) {
+      answerButtons.add(getButton(
+          questions[i], onPressed
+      ));
+    }
+
+    return Column(
+      children: <Widget>[
+        Center(
+          //child: Padding(
+          //padding: const EdgeInsets.all(40),
+          child: Column(mainAxisSize: MainAxisSize.min, children: <Widget>[
+            Padding(
+              padding: const EdgeInsets.only(right: 20),
+              child: Align(
+                  alignment: Alignment.centerRight,
+                  child: Text(
+                      'Question ${qNum + 1}${'/'}${quiz.questionList.length}')),
+            ),
+            Text(question, style: const TextStyle(fontSize: 20)),
+            const SizedBox(height: 20),
+            ListView.builder(
+                shrinkWrap: true,
+                padding: const EdgeInsets.all(20.0),
+                itemCount: answerButtons.length,
+                itemBuilder: (context, position) {
+                  return answerButtons[position];
+                }),
+          ]),
+        ),
+        //)
+      ],
+    );
+  }
+}

--- a/lib/Quizzes/QuestionSemantics/multiple_choice_question.dart
+++ b/lib/Quizzes/QuestionSemantics/multiple_choice_question.dart
@@ -1,0 +1,69 @@
+import 'package:artifact/Quizzes/QuestionSemantics/quiz_question.dart';
+import 'package:artifact/Quizzes/quiz.dart';
+import 'package:flutter/material.dart';
+
+
+class MCQuestion extends QuizQuestion {
+  String question;
+  String correctAnswer;
+  List<String> otherAnswers;
+
+  MCQuestion({required this.question,
+    required this.correctAnswer,
+    required this.otherAnswers});
+
+  static TextButton getButton(String text, Function onPressed) {
+    return TextButton(
+      onPressed: () => {
+      onPressed(text)
+    },
+      style: ButtonStyle(
+          backgroundColor: MaterialStateProperty.all(Colors.blueGrey[100])),
+      child: Text(text, style: const TextStyle(color: Colors.black)),
+    );
+  }
+
+  @override
+  Widget display({required Quiz quiz,
+    int qNum = 0,
+    required BuildContext context,
+    required Function onPressed,}) {
+    List<String> questions = List<String>.from(otherAnswers);
+    questions.add(correctAnswer);
+    questions.shuffle();
+    List<Widget> answerButtons = [];
+    for (int i = 0; i < questions.length; i++) {
+      answerButtons.add(getButton(
+          questions[i], onPressed
+      ));
+    }
+
+    return Column(
+      children: <Widget>[
+        Center(
+          //child: Padding(
+          //padding: const EdgeInsets.all(40),
+          child: Column(mainAxisSize: MainAxisSize.min, children: <Widget>[
+            Padding(
+              padding: const EdgeInsets.only(right: 20),
+              child: Align(
+                  alignment: Alignment.centerRight,
+                  child: Text(
+                      'Question ${qNum + 1}${'/'}${quiz.questionList.length}')),
+            ),
+            Text(question, style: const TextStyle(fontSize: 20)),
+            const SizedBox(height: 20),
+            ListView.builder(
+                shrinkWrap: true,
+                padding: const EdgeInsets.all(20.0),
+                itemCount: answerButtons.length,
+                itemBuilder: (context, position) {
+                  return answerButtons[position];
+                }),
+          ]),
+        ),
+        //)
+      ],
+    );
+  }
+}

--- a/lib/Quizzes/QuestionSemantics/question_screen.dart
+++ b/lib/Quizzes/QuestionSemantics/question_screen.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/material.dart';
+import '../quiz.dart';
+
+class QuestionScreen extends StatelessWidget {
+  final Quiz quiz;
+
+  const QuestionScreen({required this.quiz, super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+        backgroundColor: const Color.fromRGBO(225, 255, 195, 1),
+        body: SafeArea(
+            child: Column(mainAxisSize: MainAxisSize.min, children: <Widget>[
+          Text(quiz.name, style: const TextStyle(fontSize: 40)),
+          const SizedBox(height: 20),
+          QuestionWidget(quiz: quiz),
+        ])));
+  }
+}
+
+class QuestionWidget extends StatefulWidget {
+  final Quiz quiz;
+
+  const QuestionWidget({required this.quiz, super.key});
+
+  @override
+  QuestionState createState() => QuestionState();
+}
+
+class QuestionState extends State<QuestionWidget> {
+  int qNum = 0;
+  List<String> answers = [];
+
+  @override
+  Widget build(BuildContext context) {
+    Function onPressed;
+    if (qNum < widget.quiz.questionList.length - 1) {
+      onPressed = nextQ;
+    } else {
+      onPressed = results;
+    }
+    return widget.quiz.questionList[qNum].display(
+        quiz: widget.quiz,
+        qNum: qNum,
+        context: context,
+        onPressed: onPressed);
+  }
+
+  void results(String answer) {
+    answers.add(answer);
+    print(answers);
+    //ADD MOVING TO RESULTS SCREEN HERE, BE SURE TO BRING ANSWERS WITH YOU
+  }
+
+  void nextQ(String answer) {
+    setState(() {
+      qNum += 1;
+      answers.add(answer);
+    });
+  }
+}

--- a/lib/Quizzes/QuestionSemantics/quiz_question.dart
+++ b/lib/Quizzes/QuestionSemantics/quiz_question.dart
@@ -1,0 +1,9 @@
+
+import 'package:artifact/Quizzes/QuestionSemantics/question_screen.dart';
+import 'package:flutter/material.dart';
+import '../quiz.dart';
+
+abstract class QuizQuestion {
+
+  Widget display({required Quiz quiz, int qNum = 0, required BuildContext context, required Function onPressed});
+}

--- a/lib/Quizzes/Quizzes.dart
+++ b/lib/Quizzes/Quizzes.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:artifact/circular_dial_menu.dart';
 
+import 'Quizzes/quizDB.dart';
+
 class QuizzesScreen extends StatelessWidget {
   const QuizzesScreen({super.key});
 
@@ -8,20 +10,25 @@ class QuizzesScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       backgroundColor: const Color.fromRGBO(225, 255, 195, 1),
-      appBar: AppBar(
-        title: const Text('Quizzes'),
-      ),
-      body: Center(
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: <Widget>[
-            ElevatedButton(
-              onPressed: () {},
-              child: const Text('Sample Quiz (Not Implemented)'),
-            ),
-          ],
-        ),
-      ),
+      body: SingleChildScrollView(
+          child: SafeArea(
+            child: Column(mainAxisSize: MainAxisSize.min, children: <Widget>[
+              const Align(
+                alignment: Alignment.topLeft,
+                child: BackButton(),
+              ),
+              Center(
+                  child: Padding(
+                      padding: const EdgeInsets.all(40),
+                      child: Column(
+                        children: <Widget>[
+                          const Text('Quizzes', style: TextStyle(fontSize: 40)),
+                          const SizedBox(height: 30),
+                          QuizDB.quiz1.menuView(context),                                 //ADD OTHER QUIZZES HERE LIKE SO
+                        ],
+                      )))
+            ]),
+          )),
       floatingActionButtonLocation: FloatingActionButtonLocation.centerDocked,
       floatingActionButton: CircularDialMenu.build(context),
       bottomNavigationBar: BottomAppBar(

--- a/lib/Quizzes/Quizzes/quizDB.dart
+++ b/lib/Quizzes/Quizzes/quizDB.dart
@@ -1,0 +1,24 @@
+import 'package:artifact/Quizzes/Quizzes/quiz_questionsDB.dart';
+import 'package:flutter/cupertino.dart';
+import '../QuestionSemantics/question_screen.dart';
+
+import '../quiz.dart';
+
+class QuizDB {
+
+  //Copy and Pasteable init Template for each quiz
+  static Quiz quiz1 = Quiz(
+        name: 'Quiz1', //Change this for each quiz
+        desc: 'PlaceholderDesc', //Change this for each quiz
+        questionList: QuestionsDB.quiz1Questions()  //Change this for each quiz
+      );
+
+
+
+  static Widget? getQuestion(Quiz quiz, int qNum, BuildContext context, Function onPressed) {
+    if (qNum >= quiz.questionList.length) {
+      return null;
+    }
+    return quiz.questionList[qNum].display(quiz: quiz, qNum: qNum, context: context, onPressed: onPressed);
+  }
+}

--- a/lib/Quizzes/Quizzes/quiz_questionsDB.dart
+++ b/lib/Quizzes/Quizzes/quiz_questionsDB.dart
@@ -1,0 +1,20 @@
+import 'package:artifact/Quizzes/QuestionSemantics/multiple_choice_question.dart';
+
+import '../QuestionSemantics/TF_question.dart';
+import '../QuestionSemantics/quiz_question.dart';
+
+class QuestionsDB {
+  static List<QuizQuestion> quiz1 = [];
+
+  static List<QuizQuestion> quiz1Questions() {
+    if (quiz1.isEmpty) {
+      quiz1 = [
+        //Initialize Questions Here
+        MCQuestion(question: 'Choose A', correctAnswer: 'A', otherAnswers: ['B','C','D']),
+        MCQuestion(question: 'Choose B', correctAnswer: 'B', otherAnswers: ['B','C','D']),
+        TFQuestion(question: 'Choose True', correctAnswer: 'True'),
+      ];
+    }
+    return quiz1;
+  }
+}

--- a/lib/Quizzes/quiz.dart
+++ b/lib/Quizzes/quiz.dart
@@ -1,0 +1,47 @@
+import 'package:artifact/Quizzes/QuestionSemantics/quiz_question.dart';
+import 'package:artifact/Quizzes/start_screen.dart';
+import 'package:flutter/material.dart';
+import 'package:artifact/circular_dial_menu.dart';
+
+import 'QuestionSemantics/quiz_question.dart';
+
+class Quiz {
+  String name;
+  String desc;
+  List<QuizQuestion> questionList;
+  int score = 0;
+  int nextInd = 0;
+
+  Quiz({
+    required this.name,
+    required this.desc,
+    required this.questionList,
+  });
+
+  TextButton menuView(context) {
+    return TextButton(
+      style: ButtonStyle(backgroundColor: MaterialStateProperty.all(Colors.blueGrey[100])),
+      onPressed: () {
+        Navigator.push(
+          context,
+          MaterialPageRoute(builder: (context) => StartScreen(quiz: this)),
+        );
+      },
+      child:
+          Row(mainAxisAlignment: MainAxisAlignment.center, children: <Widget>[
+        Expanded(
+          child: Align(
+            alignment: Alignment.centerLeft,
+            child: Text(name, style: const TextStyle(color: Colors.black)),
+          ),
+        ),
+        Expanded(
+          child: Align(
+            alignment: Alignment.centerRight,
+            child: Text('ScorePlaceholder'), //Maybe style it to different colors based on x/x, 0/x, or something inbetween?
+          ),
+        )
+      ]),
+    );
+  }
+}

--- a/lib/Quizzes/start_screen.dart
+++ b/lib/Quizzes/start_screen.dart
@@ -1,0 +1,74 @@
+import 'package:artifact/Quizzes/quiz.dart';
+import 'package:flutter/material.dart';
+import 'package:artifact/circular_dial_menu.dart';
+import 'package:artifact/Musical-Terms/Term.dart';
+import '../main.dart';
+import 'QuestionSemantics/question_screen.dart';
+import 'Quizzes/quizDB.dart';
+
+class StartScreen extends StatelessWidget {
+  const StartScreen({super.key, required this.quiz});
+
+  final Quiz quiz;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: const Color.fromRGBO(225, 255, 195, 1),
+      body: SafeArea(
+        child: Column(
+          children: <Widget>[
+            const Align(
+              alignment: Alignment.topLeft,
+              child: BackButton(),
+            ),
+            Center(
+              child: Padding(
+                padding: const EdgeInsets.all(40),
+                child:
+                    Column(mainAxisSize: MainAxisSize.min, children: <Widget>[
+                  Text(quiz.name, style: const TextStyle(fontSize: 40)),
+                  const SizedBox(height: 20),
+                  Text(quiz.desc, style: const TextStyle(fontSize: 20)),
+                  const SizedBox(height: 20),
+                  TextButton(
+                    style: ButtonStyle(
+                        backgroundColor:
+                            MaterialStateProperty.all(Colors.green[600])),
+                    onPressed: () {
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute(builder: (context) => QuestionScreen(quiz: quiz)),
+                      );},
+                    child: const Text('Start!',
+                        style: TextStyle(color: Colors.black, fontSize: 30)),
+                  ),
+                ]),
+              ),
+            )
+          ],
+        ),
+      ),
+      floatingActionButtonLocation: FloatingActionButtonLocation.centerDocked,
+      floatingActionButton: CircularDialMenu.build(context),
+      bottomNavigationBar: BottomAppBar(
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+          children: [
+            IconButton(
+              onPressed: () => Navigator.push(context,
+                  MaterialPageRoute(builder: (context) => const MainScreen())),
+              tooltip: 'Home',
+              icon: const Icon(Icons.home, color: Colors.black45),
+            ),
+            IconButton(
+              onPressed: () => Navigator.pushNamed(context, '/settings'),
+              tooltip: 'Settings',
+              icon: const Icon(Icons.settings, color: Colors.black45),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
<!-- Feel free to use it and tweak some parts -->

#### Description
<!-- A general summary of your changes -->
Adds support for quizzes, with both multiple choice questions and TF questions.

#### Types of Changes
<!-- Feel free to remove the ones you don't use, or remove all of them and explain what type of change it is -->
- New feature (non-breaking change which adds functionality)

#### Notes
<!-- Extra things you want to include -->
Quizzes are currently stored in the file quizDB.dart, with a template quiz viewable. The procedure for adding a new quiz is to first add its questions to the file quiz_questionsDB.dart, as shown in the template, and to then add it to quiz.DB, again following the template, and to then finally add its .menuView() to Quizzes.dart.

Currently, answering the last question does nothing. This is pending the handling of the results screen in the function void results(String answer) in question_screen.dart.

#### Checklist
<!-- Some reminders -->
- [x] Moved the task in [Jira](https://jib-2329.atlassian.net/jira/software/projects/OM2329/boards/1) to 'In Review'
- [x] Updated the Incremental Release Notes
- [ ] Moved the task in [Jira](https://jib-2329.atlassian.net/jira/software/projects/OM2329/boards/1) to 'Done' once merged
