### PR TITLE
Global Listen

### DIFF
--- a/lib/Listen/Listen.dart
+++ b/lib/Listen/Listen.dart
@@ -13,21 +13,6 @@ class ListenScreen extends StatefulWidget {
 }
 
 class ListenScreenState extends State<ListenScreen> {
-  //late AudioPlayer _audioPlayer;
-
-  final beethovenPlaylist = ConcatenatingAudioSource(
-    children: [
-      AudioSource.uri(
-          Uri.parse('asset:///assets/music/Beethoven/Fur_Elise.mp3')),
-      AudioSource.uri(Uri.parse(
-          'asset:///assets/music/Beethoven/Sonata_8_Pathetique_1st_Movement.mp3')),
-      AudioSource.uri(Uri.parse(
-          'asset:///assets/music/Beethoven/Moonlight_Sonata_1st_Movement.mp3')),
-      AudioSource.uri(Uri.parse(
-          'asset:///assets/music/Beethoven/Sonata_1_in_F_Minor_Allegro.mp3')),
-    ],
-  );
-
   Stream<PositionData> get _positionDataStream =>
       Rx.combineLatest3<Duration, Duration, Duration?, PositionData>(
         openingState.getPlayer.positionStream,
@@ -40,10 +25,7 @@ class ListenScreenState extends State<ListenScreen> {
         ),
       );
 
-  // @override
-  // void dispose() {
-  //   super.dispose();
-  // }
+  //String title = openingState.getPlayer.sequenceState?.currentSource?.tag;
 
   @override
   Widget build(BuildContext context) {
@@ -59,7 +41,7 @@ class ListenScreenState extends State<ListenScreen> {
             ),
             Image.asset('assets/images/Beethoven.PNG'),
             Padding(
-              padding: const EdgeInsets.fromLTRB(60, 20, 60, 0),
+              padding: const EdgeInsets.fromLTRB(60, 20, 60, 20),
               child: ElevatedButton(
                 onPressed: () {
                   Navigator.pushNamed(context, '/beethoven');
@@ -67,8 +49,11 @@ class ListenScreenState extends State<ListenScreen> {
                 child: const Text('Ludwig van Beethoven'),
               ),
             ),
+            Text(openingState.getPlayer.sequenceState?.currentSource?.tag,
+              style: TextStyle(fontSize: 30, color: Colors.black), textAlign:
+              TextAlign.center,),
             Padding(
-              padding: const EdgeInsets.fromLTRB(60, 50, 60, 0),
+              padding: const EdgeInsets.fromLTRB(60, 30, 60, 0),
               child: StreamBuilder<PositionData>(
                 stream: _positionDataStream,
                 builder: (context, snapshot) {
@@ -161,4 +146,35 @@ void showSliderDialog({
       ),
     ),
   );
+}
+
+class TextChanger extends StatefulWidget {
+  const TextChanger({super.key});
+  @override
+  State<TextChanger> createState() => _TextChangerState();
+}
+class _TextChangerState extends State<TextChanger> {
+  // Declare the variable
+  String dynamicText = 'Initial Text';
+  updateText() {
+    setState(() {
+      dynamicText = 'This is new text value';
+      // Replace with your logic
+    });
+  }
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Text(
+          '$dynamicText', // Dynamic text
+          style: const TextStyle(fontSize: 28),
+        ),
+        ElevatedButton(
+          child: const Text('Change Text'),
+          onPressed: () => updateText(), // Call the method
+        ),
+      ],
+    );
+  }
 }

--- a/lib/Musical-Works/Composition-Page.dart
+++ b/lib/Musical-Works/Composition-Page.dart
@@ -6,6 +6,7 @@ import '../Composers/Composers.dart';
 import '../Musical-Works/Musical-Works-Old.dart';
 import '../Quizzes/Quizzes.dart';
 import '../main.dart';
+import '../music_box.dart';
 
 class CompScreen extends StatelessWidget {
   const CompScreen({super.key, required this.comp});
@@ -39,6 +40,20 @@ class CompScreen extends StatelessWidget {
                 const SizedBox(height: 20),
                 ElevatedButton(
                   onPressed: () {
+                    switch(comp.name) {
+                      case 'Für Elise':
+                        openingState.getPlayer.seek(Duration.zero, index: 0);
+                        break;
+                      case 'Moonlight Sonata 1st Movement':
+                        openingState.getPlayer.seek(Duration.zero, index: 2);
+                        break;
+                      case 'Sonata 1 in F Minor Allegro':
+                        openingState.getPlayer.seek(Duration.zero, index: 3);
+                        break;
+                      case 'Sonata 8 Pathetique 1st Movement':
+                        openingState.getPlayer.seek(Duration.zero, index: 1);
+                        break;
+                    }
                     Navigator.pushNamed(context, '/listen');
                   },
                   child: Text('Listen to ${comp.name}'),

--- a/lib/music_box.dart
+++ b/lib/music_box.dart
@@ -21,30 +21,30 @@ class openingState extends State<opening> {
   final beethovenPlaylist = ConcatenatingAudioSource(
     children: [
       AudioSource.uri(
-          Uri.parse('asset:///assets/music/Beethoven/Fur_Elise.mp3')),
+        Uri.parse('asset:///assets/music/Beethoven/Fur_Elise.mp3'),
+        tag: 'Für Elise',
+      ),
       AudioSource.uri(Uri.parse(
-          'asset:///assets/music/Beethoven/Sonata_8_Pathetique_1st_Movement.mp3')),
+          'asset:///assets/music/Beethoven/Sonata_8_Pathetique_1st_Movement.mp3'),
+        tag: 'Sonata 8 Pathetique 1st Movement',
+      ),
       AudioSource.uri(Uri.parse(
-          'asset:///assets/music/Beethoven/Moonlight_Sonata_1st_Movement.mp3')),
+          'asset:///assets/music/Beethoven/Moonlight_Sonata_1st_Movement.mp3'),
+        tag: 'Moonlight Sonata 1st Movement',
+      ),
       AudioSource.uri(Uri.parse(
-          'asset:///assets/music/Beethoven/Sonata_1_in_F_Minor_Allegro.mp3')),
+          'asset:///assets/music/Beethoven/Sonata_1_in_F_Minor_Allegro.mp3'),
+        tag: 'Sonata 1 in F Minor Allegro',
+      ),
     ],
   );
 
-  // Stream<PositionData> get _positionDataStream =>
-  //     Rx.combineLatest3<Duration, Duration, Duration?, PositionData>(
-  //       audioPlayer.positionStream,
-  //       audioPlayer.bufferedPositionStream,
-  //       audioPlayer.durationStream,
-  //           (position, bufferedPosition, duration) => PositionData(
-  //         position,
-  //         bufferedPosition,
-  //         duration ?? Duration.zero,
-  //       ),
-  //     );
-
   static AudioPlayer get getPlayer {
     return audioPlayer;
+  }
+
+  String get songName {
+    return audioPlayer.sequenceState?.currentSource?.tag;
   }
 
   @override
@@ -77,7 +77,7 @@ class openingState extends State<opening> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: const Color.fromRGBO(255, 255, 255, 1.0),
+      backgroundColor: const Color.fromRGBO(255, 214, 153, 1),
       body: SafeArea(
         child: Column(
           mainAxisSize: MainAxisSize.min,
@@ -94,11 +94,11 @@ class openingState extends State<opening> {
             const SizedBox(height: 100),
             Controls(player: audioPlayer)
             ,
-            Padding(
-              padding: EdgeInsets.fromLTRB(65, 0, 70, 70),
-              child: Image.asset('assets/images/music_box.png', scale: 2.6),
-            ),
-            const SizedBox(height: 50),
+            // Padding(
+            //   padding: EdgeInsets.fromLTRB(65, 0, 70, 70),
+            //   child: Image.asset('assets/images/music_box.png', scale: 2.6),
+            // ),
+            const SizedBox(height: 100),
             Align(
                 alignment: Alignment.center,
                 child: FadeInUp(duration: Duration(seconds: 4), child: bottomButton()),
@@ -116,17 +116,39 @@ class openingState extends State<opening> {
 
 class topButton extends StatelessWidget {
   Widget build(BuildContext context) {
-    return TextButton(onPressed: () => Navigator.pushNamed(context,
-        '/main'), child: const Text('Go To Home', style: TextStyle(fontSize:
-    30, color: Colors.orangeAccent)));
+    return ClipRRect(
+        borderRadius: BorderRadius.circular(30.0),
+        child: Container(
+          color: const Color.fromRGBO(255, 255, 255, 1.0),
+          padding: const EdgeInsets.all(25),
+          child: TextButton(
+            onPressed: () {
+              Navigator.pushNamed(context, '/main');
+            },
+            child: const Text('Go To Home', style: TextStyle(fontSize:
+            25, color: Colors.black)),
+          ),
+        )
+    );
   }
 }
 
 class bottomButton extends StatelessWidget {
   Widget build(BuildContext context) {
-    return TextButton(onPressed: () => Navigator.pushNamed(context, '/listen'),
-        child: const Text('What Am I Listening To?', style: TextStyle(fontSize:
-        30, color: Colors.orangeAccent)));
+    return ClipRRect(
+        borderRadius: BorderRadius.circular(30.0),
+        child: Container(
+          color: const Color.fromRGBO(255, 255, 255, 1.0),
+          padding: const EdgeInsets.all(25),
+          child: TextButton(
+            onPressed: () {
+              Navigator.pushNamed(context, '/listen');
+            },
+            child: const Text('What Am I Listening To?', style: TextStyle(fontSize:
+            25, color: Colors.black)),
+          ),
+        )
+    );
   }
 }
 
@@ -149,7 +171,25 @@ class MediaMetadata extends StatelessWidget {
     required this.artist,
   });
 
-  final
+  final String title;
+  final String artist;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(children: [
+      Text(
+        title,
+        style: TextStyle(fontSize: 25, color: Colors.black),
+        textAlign: TextAlign.center,
+      ),
+      const SizedBox(height: 8,),
+      Text(
+        artist,
+        style: TextStyle(fontSize: 25, color: Colors.black),
+        textAlign: TextAlign.center,
+      )
+    ]);
+  }
 }
 
 class Controls extends StatelessWidget {
@@ -220,6 +260,3 @@ class Controls extends StatelessWidget {
     );
   }
 }
-
-
-

--- a/lib/settings/help_menus/musical_terms_help.dart
+++ b/lib/settings/help_menus/musical_terms_help.dart
@@ -65,7 +65,7 @@ class MusicalTermsHelpScreen extends StatelessWidget {
           children: [
             IconButton(
               onPressed: () => Navigator.pushNamedAndRemoveUntil(
-                  context, '/', (route) => false),
+                  context, '/main', (route) => false),
               tooltip: 'Home',
               icon: const Icon(Icons.home, color: Colors.black45),
             ),

--- a/lib/settings/help_menus/quizzes_help.dart
+++ b/lib/settings/help_menus/quizzes_help.dart
@@ -58,7 +58,7 @@ class QuizzesHelpScreen extends StatelessWidget {
           children: [
             IconButton(
               onPressed: () => Navigator.pushNamedAndRemoveUntil(
-                  context, '/', (route) => false),
+                  context, '/main', (route) => false),
               tooltip: 'Home',
               icon: const Icon(Icons.home, color: Colors.black45),
             ),

--- a/lib/settings/help_menus/works_help.dart
+++ b/lib/settings/help_menus/works_help.dart
@@ -77,7 +77,7 @@ class WorksHelpScreen extends StatelessWidget {
           children: [
             IconButton(
               onPressed: () => Navigator.pushNamedAndRemoveUntil(
-                  context, '/', (route) => false),
+                  context, '/main', (route) => false),
               tooltip: 'Home',
               icon: const Icon(Icons.home, color: Colors.black45),
             ),

--- a/lib/splash_screen.dart
+++ b/lib/splash_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:video_player/video_player.dart';
+import '../music_box.dart';
 
 class SplashScreen extends StatefulWidget {
   const SplashScreen({Key? key}) : super(key: key);


### PR DESCRIPTION
#### Description
- 'just_audio' functionality is now a global thing that is initialized no matter what in the opening screen.
- What this means is that the bug where going to the Listen screen would allow you to create multiple streams of music is no more. If you start music in the opening screen, then go to the Listen module, the progress bar in the Listen module will align exactly with where the song is globally. There is one stream of music, and the Listen module is the controller for that.
- I could not figure out how to get the music to play automatically without user input. That functionality is not a part of this sprint.
- I also added the name of the song on the Listen module, however, I could not figure out how to get the text to update while you are still looking at the screen. This is going to be a bug going into Sprint 5.
- The 'Listen to ___' buttons in the Works module also work now and restart the player on the corresponding song to the button

#### Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/114765630/229372241-41db6a27-241e-456e-a68a-3cd50627266f.png)
![image](https://user-images.githubusercontent.com/114765630/229372253-61e5b632-3208-4774-9b5a-25f8781f13a1.png)
![image](https://user-images.githubusercontent.com/114765630/229372779-e582b4ab-5ba6-48e1-a21d-48e6b65937cc.png)

#### Types of Changes
- New feature (non-breaking change which adds functionality)
- Non-Functional Change (non-user facing changes)
- Bug fix (non-breaking change which fixes an issue)
- Breaking change (fix or feature that would cause existing functionality to change)
- 
#### Checklist
<!-- Some reminders -->
- [x] Moved the task in [Jira](https://jib-2329.atlassian.net/jira/software/projects/OM2329/boards/1) to 'In Review'
- [x] Updated the Incremental Release Notes
- [ ] Moved the task in [Jira](https://jib-2329.atlassian.net/jira/software/projects/OM2329/boards/1) to 'Done' once merged
