### PR TITLE
Refactor Bottom Navigation Buttons

### DIFF
--- a/lib/Composers/Bach.dart
+++ b/lib/Composers/Bach.dart
@@ -1,3 +1,4 @@
+import 'package:artifact/bottom_navigation_bar/bottom_button_bar.dart';
 import 'package:flutter/material.dart';
 import 'package:artifact/bottom_navigation_bar/circular_dial_menu.dart';
 
@@ -6,8 +7,9 @@ class BachScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final ButtonStyle style =
-        ElevatedButton.styleFrom(textStyle: const TextStyle(fontSize: 20));
+    final ButtonStyle style = ElevatedButton.styleFrom(
+      textStyle: const TextStyle(fontSize: 20),
+    );
 
     return Scaffold(
       backgroundColor: const Color.fromRGBO(255, 246, 167, 1),
@@ -70,23 +72,7 @@ class BachScreen extends StatelessWidget {
       ),
       floatingActionButtonLocation: FloatingActionButtonLocation.centerDocked,
       floatingActionButton: CircularDialMenu.build(context),
-      bottomNavigationBar: BottomAppBar(
-        child: Row(
-          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-          children: [
-            IconButton(
-              onPressed: () => Navigator.pushNamed(context, '/main'),
-              tooltip: 'Home',
-              icon: const Icon(Icons.home, color: Colors.black45),
-            ),
-            IconButton(
-              onPressed: () => Navigator.pushNamed(context, '/settings'),
-              tooltip: 'Settings',
-              icon: const Icon(Icons.settings, color: Colors.black45),
-            ),
-          ],
-        ),
-      ),
+      bottomNavigationBar: BottomButtonBar.build(context),
     );
   }
 }

--- a/lib/Composers/Bach.dart
+++ b/lib/Composers/Bach.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:artifact/circular_dial_menu.dart';
+import 'package:artifact/bottom_navigation_bar/circular_dial_menu.dart';
 
 class BachScreen extends StatelessWidget {
   const BachScreen({super.key});
@@ -7,7 +7,7 @@ class BachScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final ButtonStyle style =
-    ElevatedButton.styleFrom(textStyle: const TextStyle(fontSize: 20));
+        ElevatedButton.styleFrom(textStyle: const TextStyle(fontSize: 20));
 
     return Scaffold(
       backgroundColor: const Color.fromRGBO(255, 246, 167, 1),
@@ -19,40 +19,48 @@ class BachScreen extends StatelessWidget {
           margin: const EdgeInsets.all(24),
           child: Column(
             mainAxisSize: MainAxisSize.min,
-            children: <Widget>[Image.asset('assets/images/Bach.png'),
-              const Text('Early Life',
-                style: TextStyle(fontSize: 32),),
-              const Text("Johann Sebastian Bach was born on March 31, 1685, in Eisenach, Germany, into a family of musicians. "
-                  "His father, Johann Ambrosius Bach, was a court trumpeter, and his mother, Maria Elisabeth Lämmerhirt, came from a family of musicians. "
-                  "Bach was the youngest of eight children, and his parents died when he was just ten years old, leaving him and his siblings to be raised by their older brother, Johann Christoph."
-                  "\n\nUnder his brother's guidance, Bach received his early musical education and showed a remarkable talent for music from an early age. "
-                  "He learned to play the violin and the harpsichord, and by the age of ten, he was already proficient enough to join his brother's orchestra."
-                  "\n\nBach's musical education continued when he was sent to study at the prestigious St. Michael's School in Lüneburg when he was 15. "
-                  "It was here that he was exposed to a wide variety of musical styles, and he studied under the renowned organist and composer Georg Böhm. "
-                  "Bach was so skilled that he was often called upon to substitute for Böhm when he was unavailable."
-                  "\n",
+            children: <Widget>[
+              Image.asset('assets/images/Bach.png'),
+              const Text(
+                'Early Life',
+                style: TextStyle(fontSize: 32),
+              ),
+              const Text(
+                "Johann Sebastian Bach was born on March 31, 1685, in Eisenach, Germany, into a family of musicians. "
+                "His father, Johann Ambrosius Bach, was a court trumpeter, and his mother, Maria Elisabeth Lämmerhirt, came from a family of musicians. "
+                "Bach was the youngest of eight children, and his parents died when he was just ten years old, leaving him and his siblings to be raised by their older brother, Johann Christoph."
+                "\n\nUnder his brother's guidance, Bach received his early musical education and showed a remarkable talent for music from an early age. "
+                "He learned to play the violin and the harpsichord, and by the age of ten, he was already proficient enough to join his brother's orchestra."
+                "\n\nBach's musical education continued when he was sent to study at the prestigious St. Michael's School in Lüneburg when he was 15. "
+                "It was here that he was exposed to a wide variety of musical styles, and he studied under the renowned organist and composer Georg Böhm. "
+                "Bach was so skilled that he was often called upon to substitute for Böhm when he was unavailable."
+                "\n",
                 style: TextStyle(fontSize: 18),
               ),
               Image.asset('assets/images/BachPlaying.png'),
-              const Text("After completing his studies in Lüneburg, Bach began his professional career as a musician. "
-              "He secured his first job as a court musician in Weimar at the age of 18, and it was here that he began to establish himself as a composer. "
-                  "During his time in Weimar, he wrote some of his earliest compositions, including organ works and cantatas."
-                  "\n\nIn 1717, Bach accepted a position as the court organist and chamber musician for Prince Leopold of Anhalt-Köthen. "
-                  "Here, he was free to focus on instrumental music, and he composed some of his most famous instrumental works, including his Brandenburg Concertos, his suites for solo cello and solo violin, and the Goldberg Variations.\n",
+              const Text(
+                "After completing his studies in Lüneburg, Bach began his professional career as a musician. "
+                "He secured his first job as a court musician in Weimar at the age of 18, and it was here that he began to establish himself as a composer. "
+                "During his time in Weimar, he wrote some of his earliest compositions, including organ works and cantatas."
+                "\n\nIn 1717, Bach accepted a position as the court organist and chamber musician for Prince Leopold of Anhalt-Köthen. "
+                "Here, he was free to focus on instrumental music, and he composed some of his most famous instrumental works, including his Brandenburg Concertos, his suites for solo cello and solo violin, and the Goldberg Variations.\n",
                 style: TextStyle(fontSize: 18),
               ),
-              const Text('Career & Late Life',
-                style: TextStyle(fontSize: 32),),
-              const Text("After his time in Köthen, Bach moved to Leipzig in 1723, where he spent the remainder of his life as the director of music at the St. Thomas Church and School. "
-                  "This position was both prestigious and challenging, as Bach was responsible for composing music for the church's weekly services, directing the choir and orchestra, and teaching music to the school's students."
-                  "\n\nDuring his time in Leipzig, Bach composed some of his most famous works, including the St. Matthew Passion and the Mass in B Minor. "
-                  "He also continued to write cantatas and other sacred music, as well as instrumental works for the keyboard and other instruments."
-                  "\n\nBach's musical output was vast and varied, and he was a master of many different genres and styles. "
-                  "He was renowned for his complex and intricate counterpoint, his skillful use of harmony and melody, and his ability to convey a wide range of emotions through his music."
-                  "\n\nDespite his many accomplishments, Bach was not widely recognized as a great composer during his lifetime. "
-                  "It was not until several decades after his death on July 28, 1750 that his music began to be appreciated by a wider audience, and he is now considered one of the greatest composers of all time."
-                  "\n\nBach's legacy continues to live on today, and his music is still widely performed and studied. "
-                  "His influence can be heard in the works of countless composers who came after him, and his contributions to music have had a profound impact on the development of Western classical music.\n",
+              const Text(
+                'Career & Late Life',
+                style: TextStyle(fontSize: 32),
+              ),
+              const Text(
+                "After his time in Köthen, Bach moved to Leipzig in 1723, where he spent the remainder of his life as the director of music at the St. Thomas Church and School. "
+                "This position was both prestigious and challenging, as Bach was responsible for composing music for the church's weekly services, directing the choir and orchestra, and teaching music to the school's students."
+                "\n\nDuring his time in Leipzig, Bach composed some of his most famous works, including the St. Matthew Passion and the Mass in B Minor. "
+                "He also continued to write cantatas and other sacred music, as well as instrumental works for the keyboard and other instruments."
+                "\n\nBach's musical output was vast and varied, and he was a master of many different genres and styles. "
+                "He was renowned for his complex and intricate counterpoint, his skillful use of harmony and melody, and his ability to convey a wide range of emotions through his music."
+                "\n\nDespite his many accomplishments, Bach was not widely recognized as a great composer during his lifetime. "
+                "It was not until several decades after his death on July 28, 1750 that his music began to be appreciated by a wider audience, and he is now considered one of the greatest composers of all time."
+                "\n\nBach's legacy continues to live on today, and his music is still widely performed and studied. "
+                "His influence can be heard in the works of countless composers who came after him, and his contributions to music have had a profound impact on the development of Western classical music.\n",
                 style: TextStyle(fontSize: 18),
               ),
               Image.asset('assets/images/BachGrave.png'),
@@ -60,14 +68,6 @@ class BachScreen extends StatelessWidget {
           ),
         ),
       ),
-
-
-
-
-
-
-
-
       floatingActionButtonLocation: FloatingActionButtonLocation.centerDocked,
       floatingActionButton: CircularDialMenu.build(context),
       bottomNavigationBar: BottomAppBar(

--- a/lib/Composers/Beethoven.dart
+++ b/lib/Composers/Beethoven.dart
@@ -1,12 +1,11 @@
 import 'package:flutter/material.dart';
-import 'package:artifact/circular_dial_menu.dart';
+import 'package:artifact/bottom_navigation_bar/circular_dial_menu.dart';
 
 class BeethovenScreen extends StatelessWidget {
   const BeethovenScreen({super.key});
 
   @override
   Widget build(BuildContext context) {
-
     return Scaffold(
       backgroundColor: const Color.fromRGBO(255, 246, 167, 1),
       appBar: AppBar(
@@ -17,10 +16,14 @@ class BeethovenScreen extends StatelessWidget {
           margin: const EdgeInsets.all(24),
           child: Column(
             mainAxisSize: MainAxisSize.min,
-            children: <Widget>[Image.asset('assets/images/Beethoven.PNG'),
-              const Text('Early Life',
-              style: TextStyle(fontSize: 32),),
-              const Text('Ludwig van Beethoven was born on December 16, 1770, in the city of Bonn, Germany. '
+            children: <Widget>[
+              Image.asset('assets/images/Beethoven.PNG'),
+              const Text(
+                'Early Life',
+                style: TextStyle(fontSize: 32),
+              ),
+              const Text(
+                'Ludwig van Beethoven was born on December 16, 1770, in the city of Bonn, Germany. '
                 'He was the second oldest of seven children, and his father, Johann van Beethoven, was a singer and musician in the local court orchestra while Beethoven\'s mother, Maria Magdalena Keverich, came from a family of cooks and servants. '
                 '\n\nBeethoven\'s musical talent was recognized at a young age, and he began taking music lessons from his father and other local teachers. '
                 'By the age of eight, he was already playing the violin and the piano, and he began composing his own music. '
@@ -33,21 +36,24 @@ class BeethovenScreen extends StatelessWidget {
                 'Beethoven was left to care for his younger brothers, and he struggled to support his family while pursuing his music career. ',
                 style: TextStyle(fontSize: 18),
               ),
-              const Text('Career & Late Life',
-              style: TextStyle(fontSize: 32),),
-              const Text('After studying with several prominent musicians in Vienna, Beethoven established himself as a successful composer and performer. '
-                  'He began to receive commissions from wealthy patrons, including members of the nobility, and he became known throughout Europe for his innovative compositions and virtuosic piano playing. '
-                  '\n\nIn the early 1800s, Beethoven began to experience hearing loss, a condition that would eventually lead to his complete deafness. '
-                  'This was a devastating blow for Beethoven, as he was a musician who relied on his ability to hear to create his music. '
-                  'However, he continued to compose music, using his memory and imagination to create beautiful melodies. '
-                  'During this time, Beethoven wrote some of his most famous works, including his Fifth Symphony, his Moonlight Sonata, and his Ninth Symphony, which includes the famous "Ode to Joy" melody. '
-                  'These compositions are known for their emotional depth, their complexity, and their innovative use of form and structure. '
-                  '\n\nIn addition to his music, Beethoven was known for his strong personality and his commitment to social and political causes. '
-                  'He was a supporter of the French Revolution and of democratic ideals, and his music often expressed these ideals through its grandeur and power. '
-                  '\n\nDespite his growing fame and success, Beethoven continued to face personal challenges. '
-                  'He had difficulty maintaining relationships with friends and family members, and he struggled with depression and feelings of isolation. He also faced financial difficulties, as his health problems made it difficult for him to perform and to earn a steady income. '
-                  '\n\nBeethoven died on March 26, 1827, at the age of 56. He was buried in a cemetery in Vienna, where his grave can still be visited today. '
-                  'He left behind a legacy of beautiful and influential music that continues to inspire and delight people all over the world.\n',
+              const Text(
+                'Career & Late Life',
+                style: TextStyle(fontSize: 32),
+              ),
+              const Text(
+                'After studying with several prominent musicians in Vienna, Beethoven established himself as a successful composer and performer. '
+                'He began to receive commissions from wealthy patrons, including members of the nobility, and he became known throughout Europe for his innovative compositions and virtuosic piano playing. '
+                '\n\nIn the early 1800s, Beethoven began to experience hearing loss, a condition that would eventually lead to his complete deafness. '
+                'This was a devastating blow for Beethoven, as he was a musician who relied on his ability to hear to create his music. '
+                'However, he continued to compose music, using his memory and imagination to create beautiful melodies. '
+                'During this time, Beethoven wrote some of his most famous works, including his Fifth Symphony, his Moonlight Sonata, and his Ninth Symphony, which includes the famous "Ode to Joy" melody. '
+                'These compositions are known for their emotional depth, their complexity, and their innovative use of form and structure. '
+                '\n\nIn addition to his music, Beethoven was known for his strong personality and his commitment to social and political causes. '
+                'He was a supporter of the French Revolution and of democratic ideals, and his music often expressed these ideals through its grandeur and power. '
+                '\n\nDespite his growing fame and success, Beethoven continued to face personal challenges. '
+                'He had difficulty maintaining relationships with friends and family members, and he struggled with depression and feelings of isolation. He also faced financial difficulties, as his health problems made it difficult for him to perform and to earn a steady income. '
+                '\n\nBeethoven died on March 26, 1827, at the age of 56. He was buried in a cemetery in Vienna, where his grave can still be visited today. '
+                'He left behind a legacy of beautiful and influential music that continues to inspire and delight people all over the world.\n',
                 style: TextStyle(fontSize: 18),
               ),
               Image.asset('assets/images/BeethovenGrave.png'),
@@ -55,14 +61,6 @@ class BeethovenScreen extends StatelessWidget {
           ),
         ),
       ),
-
-
-
-
-
-
-
-
       floatingActionButtonLocation: FloatingActionButtonLocation.centerDocked,
       floatingActionButton: CircularDialMenu.build(context),
       bottomNavigationBar: BottomAppBar(

--- a/lib/Composers/Beethoven.dart
+++ b/lib/Composers/Beethoven.dart
@@ -1,3 +1,4 @@
+import 'package:artifact/bottom_navigation_bar/bottom_button_bar.dart';
 import 'package:flutter/material.dart';
 import 'package:artifact/bottom_navigation_bar/circular_dial_menu.dart';
 
@@ -63,23 +64,7 @@ class BeethovenScreen extends StatelessWidget {
       ),
       floatingActionButtonLocation: FloatingActionButtonLocation.centerDocked,
       floatingActionButton: CircularDialMenu.build(context),
-      bottomNavigationBar: BottomAppBar(
-        child: Row(
-          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-          children: [
-            IconButton(
-              onPressed: () => Navigator.pushNamed(context, '/main'),
-              tooltip: 'Home',
-              icon: const Icon(Icons.home, color: Colors.black45),
-            ),
-            IconButton(
-              onPressed: () => Navigator.pushNamed(context, '/settings'),
-              tooltip: 'Settings',
-              icon: const Icon(Icons.settings, color: Colors.black45),
-            ),
-          ],
-        ),
-      ),
+      bottomNavigationBar: BottomButtonBar.build(context),
     );
   }
 }

--- a/lib/Composers/Composers.dart
+++ b/lib/Composers/Composers.dart
@@ -1,6 +1,6 @@
 import 'package:artifact/Composers/Beethoven.dart';
 import 'package:flutter/material.dart';
-import 'package:artifact/circular_dial_menu.dart';
+import 'package:artifact/bottom_navigation_bar/circular_dial_menu.dart';
 
 class ComposersScreen extends StatelessWidget {
   const ComposersScreen({super.key});

--- a/lib/Composers/Composers.dart
+++ b/lib/Composers/Composers.dart
@@ -1,4 +1,5 @@
 import 'package:artifact/Composers/Beethoven.dart';
+import 'package:artifact/bottom_navigation_bar/bottom_button_bar.dart';
 import 'package:flutter/material.dart';
 import 'package:artifact/bottom_navigation_bar/circular_dial_menu.dart';
 
@@ -13,14 +14,16 @@ class ComposersScreen extends StatelessWidget {
     return Scaffold(
       backgroundColor: const Color.fromRGBO(255, 246, 167, 1),
       body: SingleChildScrollView(
-          child: SafeArea(
-        child: Column(mainAxisSize: MainAxisSize.min, children: <Widget>[
-          const Align(
-            alignment: Alignment.topLeft,
-            child: BackButton(),
-          ),
-          Center(
-              child: Padding(
+        child: SafeArea(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: <Widget>[
+              const Align(
+                alignment: Alignment.topLeft,
+                child: BackButton(),
+              ),
+              Center(
+                child: Padding(
                   padding: const EdgeInsets.all(40),
                   child: Column(
                     children: <Widget>[
@@ -28,27 +31,29 @@ class ComposersScreen extends StatelessWidget {
                       const SizedBox(height: 30),
                       MaterialButton(
                         child: ClipRRect(
-                            borderRadius: BorderRadius.circular(20),
-                            child: Stack(
-                                alignment: Alignment.bottomLeft,
-                                children: <Widget>[
-                                  Image.asset(
-                                    'assets/images/BeethovenButton.png',
-                                  ),
-                                  const Padding(
-                                      padding: EdgeInsets.all(10),
-                                      child: Text('Beethoven',
-                                          style: TextStyle(
-                                              shadows: <Shadow>[
-                                                Shadow(
-                                                  offset: Offset(0, 0),
-                                                  blurRadius: 10.0,
-                                                  color: Colors.black,
-                                                ),
-                                              ],
-                                              fontSize: 30,
-                                              color: Colors.white)))
-                                ])),
+                          borderRadius: BorderRadius.circular(20),
+                          child: Stack(
+                            alignment: Alignment.bottomLeft,
+                            children: <Widget>[
+                              Image.asset(
+                                'assets/images/BeethovenButton.png',
+                              ),
+                              const Padding(
+                                padding: EdgeInsets.all(10),
+                                child: Text(
+                                  'Beethoven',
+                                  style: TextStyle(shadows: <Shadow>[
+                                    Shadow(
+                                      offset: Offset(0, 0),
+                                      blurRadius: 10.0,
+                                      color: Colors.black,
+                                    ),
+                                  ], fontSize: 30, color: Colors.white),
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
                         onPressed: () {
                           Navigator.pushNamed(context, '/beethoven');
                         },
@@ -57,28 +62,30 @@ class ComposersScreen extends StatelessWidget {
                       const SizedBox(height: 30),
                       MaterialButton(
                         child: ClipRRect(
-                            borderRadius: BorderRadius.circular(20),
-                            // Image border
-                            child: Stack(
-                                alignment: Alignment.bottomLeft,
-                                children: <Widget>[
-                                  Image.asset(
-                                    'assets/images/MozartButton.png',
-                                  ),
-                                  const Padding(
-                                      padding: EdgeInsets.all(10),
-                                      child: Text('Mozart',
-                                          style: TextStyle(
-                                              shadows: <Shadow>[
-                                                Shadow(
-                                                  offset: Offset(0, 0),
-                                                  blurRadius: 10.0,
-                                                  color: Colors.black,
-                                                ),
-                                              ],
-                                              fontSize: 30,
-                                              color: Colors.white)))
-                                ])),
+                          borderRadius: BorderRadius.circular(20),
+                          // Image border
+                          child: Stack(
+                            alignment: Alignment.bottomLeft,
+                            children: <Widget>[
+                              Image.asset(
+                                'assets/images/MozartButton.png',
+                              ),
+                              const Padding(
+                                padding: EdgeInsets.all(10),
+                                child: Text(
+                                  'Mozart',
+                                  style: TextStyle(shadows: <Shadow>[
+                                    Shadow(
+                                      offset: Offset(0, 0),
+                                      blurRadius: 10.0,
+                                      color: Colors.black,
+                                    ),
+                                  ], fontSize: 30, color: Colors.white),
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
                         onPressed: () {
                           Navigator.pushNamed(context, '/mozart');
                         },
@@ -87,56 +94,46 @@ class ComposersScreen extends StatelessWidget {
                       const SizedBox(height: 30),
                       MaterialButton(
                         child: ClipRRect(
-                            borderRadius: BorderRadius.circular(20),
-                            // Image border
-                            child: Stack(
-                                alignment: Alignment.bottomLeft,
-                                children: <Widget>[
-                                  Image.asset(
-                                    'assets/images/BachButton.png',
-                                  ),
-                                  const Padding(
-                                      padding: EdgeInsets.all(10),
-                                      child: Text('Bach',
-                                          style: TextStyle(
-                                              shadows: <Shadow>[
-                                                Shadow(
-                                                  offset: Offset(0, 0),
-                                                  blurRadius: 10.0,
-                                                  color: Colors.black,
-                                                ),
-                                              ],
-                                              fontSize: 30,
-                                              color: Colors.white)))
-                                ])),
+                          borderRadius: BorderRadius.circular(20),
+                          // Image border
+                          child: Stack(
+                            alignment: Alignment.bottomLeft,
+                            children: <Widget>[
+                              Image.asset(
+                                'assets/images/BachButton.png',
+                              ),
+                              const Padding(
+                                padding: EdgeInsets.all(10),
+                                child: Text(
+                                  'Bach',
+                                  style: TextStyle(shadows: <Shadow>[
+                                    Shadow(
+                                      offset: Offset(0, 0),
+                                      blurRadius: 10.0,
+                                      color: Colors.black,
+                                    ),
+                                  ], fontSize: 30, color: Colors.white),
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
                         onPressed: () {
                           Navigator.pushNamed(context, '/bach');
                         },
                         //child: const Text('Beethoven'),
                       ),
                     ],
-                  )))
-        ]),
-      )),
-      floatingActionButtonLocation: FloatingActionButtonLocation.centerDocked,
-      floatingActionButton: CircularDialMenu.build(context),
-      bottomNavigationBar: BottomAppBar(
-        child: Row(
-          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-          children: [
-            IconButton(
-              onPressed: () => Navigator.pushNamed(context, '/main'),
-              tooltip: 'Home',
-              icon: const Icon(Icons.home, color: Colors.black45),
-            ),
-            IconButton(
-              onPressed: () => Navigator.pushNamed(context, '/settings'),
-              tooltip: 'Settings',
-              icon: const Icon(Icons.settings, color: Colors.black45),
-            ),
-          ],
+                  ),
+                ),
+              ),
+            ],
+          ),
         ),
       ),
+      floatingActionButtonLocation: FloatingActionButtonLocation.centerDocked,
+      floatingActionButton: CircularDialMenu.build(context),
+      bottomNavigationBar: BottomButtonBar.build(context),
     );
   }
 }

--- a/lib/Composers/Mozart.dart
+++ b/lib/Composers/Mozart.dart
@@ -1,3 +1,4 @@
+import 'package:artifact/bottom_navigation_bar/bottom_button_bar.dart';
 import 'package:flutter/material.dart';
 import 'package:artifact/bottom_navigation_bar/circular_dial_menu.dart';
 
@@ -76,23 +77,7 @@ class MozartScreen extends StatelessWidget {
       ),
       floatingActionButtonLocation: FloatingActionButtonLocation.centerDocked,
       floatingActionButton: CircularDialMenu.build(context),
-      bottomNavigationBar: BottomAppBar(
-        child: Row(
-          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-          children: [
-            IconButton(
-              onPressed: () => Navigator.pushNamed(context, '/main'),
-              tooltip: 'Home',
-              icon: const Icon(Icons.home, color: Colors.black45),
-            ),
-            IconButton(
-              onPressed: () => Navigator.pushNamed(context, '/settings'),
-              tooltip: 'Settings',
-              icon: const Icon(Icons.settings, color: Colors.black45),
-            ),
-          ],
-        ),
-      ),
+      bottomNavigationBar: BottomButtonBar.build(context),
     );
   }
 }

--- a/lib/Composers/Mozart.dart
+++ b/lib/Composers/Mozart.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:artifact/circular_dial_menu.dart';
+import 'package:artifact/bottom_navigation_bar/circular_dial_menu.dart';
 
 class MozartScreen extends StatelessWidget {
   const MozartScreen({super.key});
@@ -7,7 +7,7 @@ class MozartScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final ButtonStyle style =
-    ElevatedButton.styleFrom(textStyle: const TextStyle(fontSize: 20));
+        ElevatedButton.styleFrom(textStyle: const TextStyle(fontSize: 20));
 
     return Scaffold(
       backgroundColor: const Color.fromRGBO(255, 246, 167, 1),
@@ -19,46 +19,54 @@ class MozartScreen extends StatelessWidget {
           margin: const EdgeInsets.all(24),
           child: Column(
             mainAxisSize: MainAxisSize.min,
-            children: <Widget>[Image.asset('assets/images/Mozart.png'),
-              const Text('Early Life',
-                style: TextStyle(fontSize: 32),),
-              const Text('Wolfgang Amadeus Mozart was born on January 27, 1756, in Salzburg, Austria. '
-                  'He was the youngest of seven children, and his father, Leopold Mozart, was a musician and composer in the service of the Archbishop of Salzburg.\n\n'
-                  'Mozart showed remarkable musical talent at a very young age. '
-                  'By the time he was three years old, he was playing the keyboard and composing his own music. '
-                  'He and his older sister, Nannerl, were often sent on concert tours by their father, performing for audiences throughout Europe and earning great acclaim for their virtuosic playing.\n\n'
-                  'At the age of six, Mozart began formal music lessons with his father, who was a strict and demanding teacher. '
-                  'However, Mozart\'s talent was so great that he quickly outstripped his father\'s teaching and began to develop his own unique style.\n',
-                  style: TextStyle(fontSize: 18),
+            children: <Widget>[
+              Image.asset('assets/images/Mozart.png'),
+              const Text(
+                'Early Life',
+                style: TextStyle(fontSize: 32),
               ),
-              Image.asset('assets/images/MozartLearning.png'),
-              const Text('\nDespite his success as a child prodigy, Mozart\'s childhood was not always easy.'
-                  'He and his family often faced financial difficulties, and they were frequently on the move, traveling from one city to another to perform for wealthy patrons. '
-                  'Mozart\'s mother, Anna Maria, died when he was just 14 years old, and he was left to cope with his grief while continuing to pursue his music career.'
-                  '\n\nDespite these challenges, Mozart continued to compose music of extraordinary beauty and complexity. '
-                  'His early works, such as his piano sonatas and string quartets, were marked by their elegance, grace, and emotional depth.'
-                  '\n\nAs Mozart entered his teenage years, he began to establish himself as a composer and performer in his own right. '
-                  'He wrote operas, symphonies, and chamber music, and he became known throughout Europe for his innovation and his technical skill. '
-                  'In 1770, at the age of just 14, he was appointed as the concertmaster of the Archbishop of Salzburg\'s orchestra, making him one of the youngest musicians ever to hold such a position.',
+              const Text(
+                'Wolfgang Amadeus Mozart was born on January 27, 1756, in Salzburg, Austria. '
+                'He was the youngest of seven children, and his father, Leopold Mozart, was a musician and composer in the service of the Archbishop of Salzburg.\n\n'
+                'Mozart showed remarkable musical talent at a very young age. '
+                'By the time he was three years old, he was playing the keyboard and composing his own music. '
+                'He and his older sister, Nannerl, were often sent on concert tours by their father, performing for audiences throughout Europe and earning great acclaim for their virtuosic playing.\n\n'
+                'At the age of six, Mozart began formal music lessons with his father, who was a strict and demanding teacher. '
+                'However, Mozart\'s talent was so great that he quickly outstripped his father\'s teaching and began to develop his own unique style.\n',
                 style: TextStyle(fontSize: 18),
               ),
-              const Text('Career & Late Life',
-                style: TextStyle(fontSize: 32),),
+              Image.asset('assets/images/MozartLearning.png'),
+              const Text(
+                '\nDespite his success as a child prodigy, Mozart\'s childhood was not always easy.'
+                'He and his family often faced financial difficulties, and they were frequently on the move, traveling from one city to another to perform for wealthy patrons. '
+                'Mozart\'s mother, Anna Maria, died when he was just 14 years old, and he was left to cope with his grief while continuing to pursue his music career.'
+                '\n\nDespite these challenges, Mozart continued to compose music of extraordinary beauty and complexity. '
+                'His early works, such as his piano sonatas and string quartets, were marked by their elegance, grace, and emotional depth.'
+                '\n\nAs Mozart entered his teenage years, he began to establish himself as a composer and performer in his own right. '
+                'He wrote operas, symphonies, and chamber music, and he became known throughout Europe for his innovation and his technical skill. '
+                'In 1770, at the age of just 14, he was appointed as the concertmaster of the Archbishop of Salzburg\'s orchestra, making him one of the youngest musicians ever to hold such a position.',
+                style: TextStyle(fontSize: 18),
+              ),
+              const Text(
+                'Career & Late Life',
+                style: TextStyle(fontSize: 32),
+              ),
               Image.asset('assets/images/MozartComposing.png'),
-              const Text("\nAs Mozart progressed into his teenage years, he continued to hone his musical abilities and establish himself as both a composer and performer. "
-                  "At the age of just 14, he became the concertmaster of the Archbishop of Salzburg's orchestra - one of the youngest musicians ever to hold such a position. \n\n"
-                  "Though he had achieved success in Salzburg, Mozart yearned to establish himself as an independent composer rather than solely a performer. "
-                  "In 1777, he left Salzburg for Mannheim, which was a hub of musical activity during that time. "
-                  "It was in Mannheim that he fell in love with Aloysia Weber, a singer and daughter of a notable musical family. \n\n"
-                  "Mozart and Aloysia were then engaged, but unfortunately, the relationship ultimately ended, partially due to Mozart's father's disapproval. "
-                  "Despite the heartbreak, Mozart continued to compose beautiful and complex music."
-                  " \n\nIn 1781, Mozart received a commission to compose an opera for the National Theater in Vienna. "
-                  "\"Idomeneo,\" the opera he composed, was a huge success, which led to further commissions and cemented his position as one of the leading composers of his time. "
-                  "\n\nThroughout the 1780s, Mozart composed operas, symphonies, chamber music, and concertos that were both accessible to the general public and intellectually challenging for advanced listeners. "
-                  "However, financial difficulties plagued him throughout his life, and he often had to rely on commissions and patronage to make ends meet. \n\n"
-                  "Even still, Mozart left an enduring legacy with his works such as \"The Marriage of Figaro,\" his \"Jupiter\" Symphony, and his Requiem Mass. "
-                  "\n\nMozart died on December 5, 1791, at the age of 35, due to a fever and possibly kidney failure."
-                  " Even though his life was relatively short, Mozart's impact on the world of music remains unparalleled, and his music continues to be celebrated and performed to this day.\n",
+              const Text(
+                "\nAs Mozart progressed into his teenage years, he continued to hone his musical abilities and establish himself as both a composer and performer. "
+                "At the age of just 14, he became the concertmaster of the Archbishop of Salzburg's orchestra - one of the youngest musicians ever to hold such a position. \n\n"
+                "Though he had achieved success in Salzburg, Mozart yearned to establish himself as an independent composer rather than solely a performer. "
+                "In 1777, he left Salzburg for Mannheim, which was a hub of musical activity during that time. "
+                "It was in Mannheim that he fell in love with Aloysia Weber, a singer and daughter of a notable musical family. \n\n"
+                "Mozart and Aloysia were then engaged, but unfortunately, the relationship ultimately ended, partially due to Mozart's father's disapproval. "
+                "Despite the heartbreak, Mozart continued to compose beautiful and complex music."
+                " \n\nIn 1781, Mozart received a commission to compose an opera for the National Theater in Vienna. "
+                "\"Idomeneo,\" the opera he composed, was a huge success, which led to further commissions and cemented his position as one of the leading composers of his time. "
+                "\n\nThroughout the 1780s, Mozart composed operas, symphonies, chamber music, and concertos that were both accessible to the general public and intellectually challenging for advanced listeners. "
+                "However, financial difficulties plagued him throughout his life, and he often had to rely on commissions and patronage to make ends meet. \n\n"
+                "Even still, Mozart left an enduring legacy with his works such as \"The Marriage of Figaro,\" his \"Jupiter\" Symphony, and his Requiem Mass. "
+                "\n\nMozart died on December 5, 1791, at the age of 35, due to a fever and possibly kidney failure."
+                " Even though his life was relatively short, Mozart's impact on the world of music remains unparalleled, and his music continues to be celebrated and performed to this day.\n",
                 style: TextStyle(fontSize: 18),
               ),
               Image.asset('assets/images/MozartGrave.png'),
@@ -66,14 +74,6 @@ class MozartScreen extends StatelessWidget {
           ),
         ),
       ),
-
-
-
-
-
-
-
-
       floatingActionButtonLocation: FloatingActionButtonLocation.centerDocked,
       floatingActionButton: CircularDialMenu.build(context),
       bottomNavigationBar: BottomAppBar(

--- a/lib/Listen/Listen.dart
+++ b/lib/Listen/Listen.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:just_audio/just_audio.dart';
-import 'package:artifact/circular_dial_menu.dart';
+import 'package:artifact/bottom_navigation_bar/circular_dial_menu.dart';
 import 'package:rxdart/rxdart.dart';
 import 'package:audio_video_progress_bar/audio_video_progress_bar.dart';
 import '../music_box.dart';
@@ -37,7 +37,7 @@ class ListenScreenState extends State<ListenScreen> {
           children: [
             const Align(
               alignment: Alignment.topLeft,
-              child: BackButton(),//onPressed: ),
+              child: BackButton(), //onPressed: ),
             ),
             Image.asset('assets/images/Beethoven.PNG'),
             Padding(
@@ -49,9 +49,11 @@ class ListenScreenState extends State<ListenScreen> {
                 child: const Text('Ludwig van Beethoven'),
               ),
             ),
-            Text(openingState.getPlayer.sequenceState?.currentSource?.tag,
-              style: TextStyle(fontSize: 30, color: Colors.black), textAlign:
-              TextAlign.center,),
+            Text(
+              openingState.getPlayer.sequenceState?.currentSource?.tag,
+              style: TextStyle(fontSize: 30, color: Colors.black),
+              textAlign: TextAlign.center,
+            ),
             Padding(
               padding: const EdgeInsets.fromLTRB(60, 30, 60, 0),
               child: StreamBuilder<PositionData>(
@@ -153,6 +155,7 @@ class TextChanger extends StatefulWidget {
   @override
   State<TextChanger> createState() => _TextChangerState();
 }
+
 class _TextChangerState extends State<TextChanger> {
   // Declare the variable
   String dynamicText = 'Initial Text';
@@ -162,6 +165,7 @@ class _TextChangerState extends State<TextChanger> {
       // Replace with your logic
     });
   }
+
   @override
   Widget build(BuildContext context) {
     return Column(

--- a/lib/Listen/Listen.dart
+++ b/lib/Listen/Listen.dart
@@ -1,3 +1,4 @@
+import 'package:artifact/bottom_navigation_bar/bottom_button_bar.dart';
 import 'package:flutter/material.dart';
 import 'package:just_audio/just_audio.dart';
 import 'package:artifact/bottom_navigation_bar/circular_dial_menu.dart';
@@ -83,27 +84,7 @@ class ListenScreenState extends State<ListenScreen> {
       ),
       floatingActionButtonLocation: FloatingActionButtonLocation.centerDocked,
       floatingActionButton: CircularDialMenu.build(context),
-      bottomNavigationBar: BottomAppBar(
-        child: Row(
-          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-          children: [
-            IconButton(
-              onPressed: () => {
-                Navigator.pushNamed(context, '/main'),
-              },
-              tooltip: 'Home',
-              icon: const Icon(Icons.home, color: Colors.black45),
-            ),
-            IconButton(
-              onPressed: () => {
-                Navigator.pushNamed(context, '/settings'),
-              },
-              tooltip: 'Settings',
-              icon: const Icon(Icons.settings, color: Colors.black45),
-            ),
-          ],
-        ),
-      ),
+      bottomNavigationBar: BottomButtonBar.build(context),
     );
   }
 }
@@ -130,11 +111,14 @@ void showSliderDialog({
           height: 100.0,
           child: Column(
             children: [
-              Text('${snapshot.data?.toStringAsFixed(1)}$valueSuffix',
-                  style: const TextStyle(
-                      fontFamily: 'Fixed',
-                      fontWeight: FontWeight.bold,
-                      fontSize: 24.0)),
+              Text(
+                '${snapshot.data?.toStringAsFixed(1)}$valueSuffix',
+                style: const TextStyle(
+                  fontFamily: 'Fixed',
+                  fontWeight: FontWeight.bold,
+                  fontSize: 24.0,
+                ),
+              ),
               Slider(
                 divisions: divisions,
                 min: min,
@@ -160,10 +144,12 @@ class _TextChangerState extends State<TextChanger> {
   // Declare the variable
   String dynamicText = 'Initial Text';
   updateText() {
-    setState(() {
-      dynamicText = 'This is new text value';
-      // Replace with your logic
-    });
+    setState(
+      () {
+        dynamicText = 'This is new text value';
+        // Replace with your logic
+      },
+    );
   }
 
   @override

--- a/lib/Musical-Terms/Definition-Page.dart
+++ b/lib/Musical-Terms/Definition-Page.dart
@@ -1,3 +1,4 @@
+import 'package:artifact/bottom_navigation_bar/bottom_button_bar.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:artifact/bottom_navigation_bar/circular_dial_menu.dart';
@@ -27,14 +28,19 @@ class DefScreen extends StatelessWidget {
             Center(
               child: Padding(
                 padding: const EdgeInsets.all(40),
-                child:
-                    Column(mainAxisSize: MainAxisSize.min, children: <Widget>[
-                  Text(term.name, style: const TextStyle(fontSize: 40)),
-                  const SizedBox(height: 20),
-                  term.getDefinition(context),
-                  const SizedBox(height: 20),
-                  term.getExamples(context)
-                ]),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: <Widget>[
+                    Text(
+                      term.name,
+                      style: const TextStyle(fontSize: 40),
+                    ),
+                    const SizedBox(height: 20),
+                    term.getDefinition(context),
+                    const SizedBox(height: 20),
+                    term.getExamples(context),
+                  ],
+                ),
               ),
             )
           ],
@@ -42,24 +48,7 @@ class DefScreen extends StatelessWidget {
       ),
       floatingActionButtonLocation: FloatingActionButtonLocation.centerDocked,
       floatingActionButton: CircularDialMenu.build(context),
-      bottomNavigationBar: BottomAppBar(
-        child: Row(
-          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-          children: [
-            IconButton(
-              onPressed: () => Navigator.push(context,
-                  MaterialPageRoute(builder: (context) => const MainScreen())),
-              tooltip: 'Home',
-              icon: const Icon(Icons.home, color: Colors.black45),
-            ),
-            IconButton(
-              onPressed: () => Navigator.pushNamed(context, '/settings'),
-              tooltip: 'Settings',
-              icon: const Icon(Icons.settings, color: Colors.black45),
-            ),
-          ],
-        ),
-      ),
+      bottomNavigationBar: BottomButtonBar.build(context),
     );
   }
 }

--- a/lib/Musical-Terms/Definition-Page.dart
+++ b/lib/Musical-Terms/Definition-Page.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
-import 'package:artifact/circular_dial_menu.dart';
+import 'package:artifact/bottom_navigation_bar/circular_dial_menu.dart';
 import 'package:artifact/Musical-Terms/Term.dart';
 import '../Composers/Composers.dart';
 import '../Musical-Works/Musical-Works-Old.dart';

--- a/lib/Musical-Terms/Musical-Terms.dart
+++ b/lib/Musical-Terms/Musical-Terms.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:artifact/Musical-Terms/Term.dart';
 import 'package:artifact/Musical-Terms/TermsDB.dart';
-import 'package:artifact/circular_dial_menu.dart';
+import 'package:artifact/bottom_navigation_bar/circular_dial_menu.dart';
 
 class TermsScreen extends StatefulWidget {
   const TermsScreen({super.key});
@@ -81,13 +81,13 @@ class TermsScreenState extends State<TermsScreen> {
             SizedBox(
               height: 600,
               child: ListView.builder(
-                shrinkWrap: true,
-                padding: const EdgeInsets.all(20.0),
-                itemCount: backingList.length,
-                itemBuilder: (context, position) {
-                  return backingList[position].menuView(context);
-                }),
-              ),
+                  shrinkWrap: true,
+                  padding: const EdgeInsets.all(20.0),
+                  itemCount: backingList.length,
+                  itemBuilder: (context, position) {
+                    return backingList[position].menuView(context);
+                  }),
+            ),
           ],
         )),
       ])),

--- a/lib/Musical-Terms/Musical-Terms.dart
+++ b/lib/Musical-Terms/Musical-Terms.dart
@@ -1,3 +1,4 @@
+import 'package:artifact/bottom_navigation_bar/bottom_button_bar.dart';
 import 'package:flutter/material.dart';
 import 'package:artifact/Musical-Terms/Term.dart';
 import 'package:artifact/Musical-Terms/TermsDB.dart';
@@ -27,89 +28,94 @@ class TermsScreenState extends State<TermsScreen> {
     return Scaffold(
       backgroundColor: const Color.fromRGBO(239, 199, 199, 1),
       body: SafeArea(
-          child: Column(children: <Widget>[
-        const Align(
-          alignment: Alignment.topLeft,
-          child: BackButton(),
-        ),
-        Center(
-            child: Column(
-          mainAxisSize: MainAxisSize.min,
+        child: Column(
           children: <Widget>[
-            Row(children: <Widget>[
-              const SizedBox(width: 125),
-              const Expanded(
-                  child: Align(
-                alignment: Alignment.center,
-                child: Text('Terms', style: TextStyle(fontSize: 40)),
-              )),
-              Container(
-                width: 100,
-                child: Align(
-                    alignment: Alignment.centerRight,
-                    child: DropdownButton<String>(
-                      onChanged: (String? newValue) {
-                        setState(() {
-                          dropdownVal = newValue!;
-                          if (newValue == 'A-Z') {
-                            backingList = TermsDB.sortAlphabetically();
-                          } else if (newValue == 'Z-A') {
-                            backingList = TermsDB.sortReverseAlphabetically();
-                          } else {
-                            TermsDB.sortAlphabetically();
-                            backingList = TermsDB.sortByTag();
-                          }
-                        });
+            const Align(
+              alignment: Alignment.topLeft,
+              child: BackButton(),
+            ),
+            Center(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: <Widget>[
+                  Row(
+                    children: <Widget>[
+                      const SizedBox(width: 125),
+                      const Expanded(
+                        child: Align(
+                          alignment: Alignment.center,
+                          child: Text(
+                            'Terms',
+                            style: TextStyle(fontSize: 40),
+                          ),
+                        ),
+                      ),
+                      Container(
+                        width: 100,
+                        child: Align(
+                          alignment: Alignment.centerRight,
+                          child: DropdownButton<String>(
+                            onChanged: (String? newValue) {
+                              setState(
+                                () {
+                                  dropdownVal = newValue!;
+                                  if (newValue == 'A-Z') {
+                                    backingList = TermsDB.sortAlphabetically();
+                                  } else if (newValue == 'Z-A') {
+                                    backingList =
+                                        TermsDB.sortReverseAlphabetically();
+                                  } else {
+                                    TermsDB.sortAlphabetically();
+                                    backingList = TermsDB.sortByTag();
+                                  }
+                                },
+                              );
+                            },
+                            value: dropdownVal,
+                            icon: const Icon(Icons.arrow_downward),
+                            items: getDropdownItems(),
+                          ),
+                        ),
+                      ),
+                      const SizedBox(width: 25),
+                    ],
+                  ),
+                  Row(
+                    children: const <Widget>[
+                      SizedBox(width: 25),
+                      Expanded(
+                        child: Align(
+                          alignment: Alignment.centerLeft,
+                          child: Text("Term"),
+                        ),
+                      ),
+                      Align(
+                        alignment: Alignment.centerRight,
+                        child: Text("Tags"),
+                      ),
+                      SizedBox(width: 25),
+                    ],
+                  ),
+                  SizedBox(
+                    height: 600,
+                    child: ListView.builder(
+                      shrinkWrap: true,
+                      padding: const EdgeInsets.all(20.0),
+                      itemCount: backingList.length,
+                      itemBuilder: (context, position) {
+                        return backingList[position].menuView(context);
                       },
-                      value: dropdownVal,
-                      icon: const Icon(Icons.arrow_downward),
-                      items: getDropdownItems(),
-                    )),
+                    ),
+                  ),
+                ],
               ),
-              const SizedBox(width: 25),
-            ]),
-            Row(children: const <Widget>[
-              SizedBox(width: 25),
-              Expanded(
-                  child: Align(
-                alignment: Alignment.centerLeft,
-                child: Text("Term"),
-              )),
-              Align(alignment: Alignment.centerRight, child: Text("Tags")),
-              SizedBox(width: 25),
-            ]),
-            SizedBox(
-              height: 600,
-              child: ListView.builder(
-                  shrinkWrap: true,
-                  padding: const EdgeInsets.all(20.0),
-                  itemCount: backingList.length,
-                  itemBuilder: (context, position) {
-                    return backingList[position].menuView(context);
-                  }),
-            ),
-          ],
-        )),
-      ])),
-      floatingActionButtonLocation: FloatingActionButtonLocation.centerDocked,
-      floatingActionButton: CircularDialMenu.build(context),
-      bottomNavigationBar: BottomAppBar(
-        child: Row(
-          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-          children: [
-            IconButton(
-              onPressed: () => Navigator.pushNamed(context, '/main'),
-              tooltip: 'Home',
-              icon: const Icon(Icons.home, color: Colors.black45),
-            ),
-            IconButton(
-              onPressed: () => Navigator.pushNamed(context, '/settings'),
-              tooltip: 'Settings',
-              icon: const Icon(Icons.settings, color: Colors.black45),
             ),
           ],
         ),
       ),
+      floatingActionButtonLocation: FloatingActionButtonLocation.centerDocked,
+      floatingActionButton: CircularDialMenu.build(context),
+      bottomNavigationBar: BottomButtonBar.build(context),
     );
   }
 }

--- a/lib/Musical-Works/Composition-Page.dart
+++ b/lib/Musical-Works/Composition-Page.dart
@@ -1,3 +1,4 @@
+import 'package:artifact/bottom_navigation_bar/bottom_button_bar.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:artifact/bottom_navigation_bar/circular_dial_menu.dart';
@@ -17,7 +18,9 @@ class CompScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       backgroundColor: const Color.fromRGBO(196, 236, 249, 1),
-      appBar: AppBar(backgroundColor: Colors.blue.withOpacity(0)),
+      appBar: AppBar(
+        backgroundColor: Colors.blue.withOpacity(0),
+      ),
       body: SingleChildScrollView(
         child: Column(
           children: <Widget>[
@@ -28,66 +31,55 @@ class CompScreen extends StatelessWidget {
             Center(
               child: Padding(
                 padding: const EdgeInsets.all(30),
-                child:
-                    Column(mainAxisSize: MainAxisSize.min, children: <Widget>[
-                  Text(
-                    comp.name,
-                    style: const TextStyle(fontSize: 40),
-                    textAlign: TextAlign.center,
-                  ),
-                  const SizedBox(height: 20),
-                  comp.getComposer(context),
-                  const SizedBox(height: 20),
-                  comp.getDescription(context),
-                  const SizedBox(height: 20),
-                  comp.getExamples(context),
-                  const SizedBox(height: 20),
-                  ElevatedButton(
-                    onPressed: () {
-                      switch (comp.name) {
-                        case 'Für Elise':
-                          openingState.getPlayer.seek(Duration.zero, index: 0);
-                          break;
-                        case 'Moonlight Sonata 1st Movement':
-                          openingState.getPlayer.seek(Duration.zero, index: 2);
-                          break;
-                        case 'Sonata 1 in F Minor Allegro':
-                          openingState.getPlayer.seek(Duration.zero, index: 3);
-                          break;
-                        case 'Sonata 8 Pathetique 1st Movement':
-                          openingState.getPlayer.seek(Duration.zero, index: 1);
-                          break;
-                      }
-                      Navigator.pushNamed(context, '/listen');
-                    },
-                    child: Text('Listen to ${comp.name}'),
-                  ),
-                ]),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: <Widget>[
+                    Text(
+                      comp.name,
+                      style: const TextStyle(fontSize: 40),
+                      textAlign: TextAlign.center,
+                    ),
+                    const SizedBox(height: 20),
+                    comp.getComposer(context),
+                    const SizedBox(height: 20),
+                    comp.getDescription(context),
+                    const SizedBox(height: 20),
+                    comp.getExamples(context),
+                    const SizedBox(height: 20),
+                    ElevatedButton(
+                      onPressed: () {
+                        switch (comp.name) {
+                          case 'Für Elise':
+                            openingState.getPlayer
+                                .seek(Duration.zero, index: 0);
+                            break;
+                          case 'Moonlight Sonata 1st Movement':
+                            openingState.getPlayer
+                                .seek(Duration.zero, index: 2);
+                            break;
+                          case 'Sonata 1 in F Minor Allegro':
+                            openingState.getPlayer
+                                .seek(Duration.zero, index: 3);
+                            break;
+                          case 'Sonata 8 Pathetique 1st Movement':
+                            openingState.getPlayer
+                                .seek(Duration.zero, index: 1);
+                            break;
+                        }
+                        Navigator.pushNamed(context, '/listen');
+                      },
+                      child: Text('Listen to ${comp.name}'),
+                    ),
+                  ],
+                ),
               ),
-            )
+            ),
           ],
         ),
       ),
       floatingActionButtonLocation: FloatingActionButtonLocation.centerDocked,
       floatingActionButton: CircularDialMenu.build(context),
-      bottomNavigationBar: BottomAppBar(
-        child: Row(
-          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-          children: [
-            IconButton(
-              onPressed: () => Navigator.push(context,
-                  MaterialPageRoute(builder: (context) => const MainScreen())),
-              tooltip: 'Home',
-              icon: const Icon(Icons.home, color: Colors.black45),
-            ),
-            IconButton(
-              onPressed: () => Navigator.pushNamed(context, '/settings'),
-              tooltip: 'Settings',
-              icon: const Icon(Icons.settings, color: Colors.black45),
-            ),
-          ],
-        ),
-      ),
+      bottomNavigationBar: BottomButtonBar.build(context),
     );
   }
 }

--- a/lib/Musical-Works/Composition-Page.dart
+++ b/lib/Musical-Works/Composition-Page.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
-import 'package:artifact/circular_dial_menu.dart';
+import 'package:artifact/bottom_navigation_bar/circular_dial_menu.dart';
 import 'package:artifact/Musical-Works/Composition.dart';
 import '../Composers/Composers.dart';
 import '../Musical-Works/Musical-Works-Old.dart';
@@ -17,50 +17,54 @@ class CompScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       backgroundColor: const Color.fromRGBO(196, 236, 249, 1),
-      appBar: AppBar(
-        backgroundColor: Colors.blue.withOpacity(0)
-      ),
+      appBar: AppBar(backgroundColor: Colors.blue.withOpacity(0)),
       body: SingleChildScrollView(
-        child: Column(children: <Widget>[
-          // const Align(
-          //   alignment: Alignment.topLeft,
-          //   child: BackButton(),
-          // ),
-          Center(
-            child: Padding(
-              padding: const EdgeInsets.all(30),
-              child: Column(mainAxisSize: MainAxisSize.min, children: <Widget>[
-                Text(comp.name, style: const TextStyle(fontSize: 40), textAlign: TextAlign.center,),
-                const SizedBox(height: 20),
-                comp.getComposer(context),
-                const SizedBox(height: 20),
-                comp.getDescription(context),
-                const SizedBox(height: 20),
-                comp.getExamples(context),
-                const SizedBox(height: 20),
-                ElevatedButton(
-                  onPressed: () {
-                    switch(comp.name) {
-                      case 'Für Elise':
-                        openingState.getPlayer.seek(Duration.zero, index: 0);
-                        break;
-                      case 'Moonlight Sonata 1st Movement':
-                        openingState.getPlayer.seek(Duration.zero, index: 2);
-                        break;
-                      case 'Sonata 1 in F Minor Allegro':
-                        openingState.getPlayer.seek(Duration.zero, index: 3);
-                        break;
-                      case 'Sonata 8 Pathetique 1st Movement':
-                        openingState.getPlayer.seek(Duration.zero, index: 1);
-                        break;
-                    }
-                    Navigator.pushNamed(context, '/listen');
-                  },
-                  child: Text('Listen to ${comp.name}'),
-                ),
-              ]),
-            ),
-          )
+        child: Column(
+          children: <Widget>[
+            // const Align(
+            //   alignment: Alignment.topLeft,
+            //   child: BackButton(),
+            // ),
+            Center(
+              child: Padding(
+                padding: const EdgeInsets.all(30),
+                child:
+                    Column(mainAxisSize: MainAxisSize.min, children: <Widget>[
+                  Text(
+                    comp.name,
+                    style: const TextStyle(fontSize: 40),
+                    textAlign: TextAlign.center,
+                  ),
+                  const SizedBox(height: 20),
+                  comp.getComposer(context),
+                  const SizedBox(height: 20),
+                  comp.getDescription(context),
+                  const SizedBox(height: 20),
+                  comp.getExamples(context),
+                  const SizedBox(height: 20),
+                  ElevatedButton(
+                    onPressed: () {
+                      switch (comp.name) {
+                        case 'Für Elise':
+                          openingState.getPlayer.seek(Duration.zero, index: 0);
+                          break;
+                        case 'Moonlight Sonata 1st Movement':
+                          openingState.getPlayer.seek(Duration.zero, index: 2);
+                          break;
+                        case 'Sonata 1 in F Minor Allegro':
+                          openingState.getPlayer.seek(Duration.zero, index: 3);
+                          break;
+                        case 'Sonata 8 Pathetique 1st Movement':
+                          openingState.getPlayer.seek(Duration.zero, index: 1);
+                          break;
+                      }
+                      Navigator.pushNamed(context, '/listen');
+                    },
+                    child: Text('Listen to ${comp.name}'),
+                  ),
+                ]),
+              ),
+            )
           ],
         ),
       ),

--- a/lib/Musical-Works/Musical-Compositions.dart
+++ b/lib/Musical-Works/Musical-Compositions.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:artifact/Musical-Works/Composition.dart';
 import 'package:artifact/Musical-Works/CompositionsDB.dart';
-import 'package:artifact/circular_dial_menu.dart';
+import 'package:artifact/bottom_navigation_bar/circular_dial_menu.dart';
 
 class CompScreen extends StatefulWidget {
   const CompScreen({super.key});
@@ -16,47 +16,45 @@ class CompScreenState extends State<CompScreen> {
 
   @override
   Widget build(BuildContext context) {
-
     return Scaffold(
       backgroundColor: const Color.fromRGBO(196, 236, 249, 1),
       body: SafeArea(
-        child: Column(
+          child: Column(children: <Widget>[
+        const Align(
+          alignment: Alignment.topLeft,
+          child: BackButton(),
+        ),
+        Center(
+            child: Column(
+          mainAxisSize: MainAxisSize.min,
           children: <Widget>[
-            const Align(
-              alignment: Alignment.topLeft,
-              child: BackButton(),
-            ),
-            Center(
-              child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: <Widget>[
-              Row(children: const <Widget>[
-                SizedBox(width: 125),
-                Expanded(
-                    child: Align(
-                  alignment: Alignment.center,
-                  child: Text('Works', style: TextStyle(fontSize: 40)),
-                )),
-                SizedBox(width: 115),
-              ]),
-              Row(children: const <Widget>[
-                SizedBox(width: 15),
-                Expanded(
-                    child: Align(
-                  alignment: Alignment.centerLeft,
-                  child: Text("Composition"),
-                )),
-              ]),
-              ListView.builder(
-                  shrinkWrap: true,
-                  padding: const EdgeInsets.all(5.0),
-                  itemCount: backingList.length,
-                  itemBuilder: (context, position) {
-                    return backingList[position].menuView(context);
-                  }),
-            ],
-          )),
-        ])),
+            Row(children: const <Widget>[
+              SizedBox(width: 125),
+              Expanded(
+                  child: Align(
+                alignment: Alignment.center,
+                child: Text('Works', style: TextStyle(fontSize: 40)),
+              )),
+              SizedBox(width: 115),
+            ]),
+            Row(children: const <Widget>[
+              SizedBox(width: 15),
+              Expanded(
+                  child: Align(
+                alignment: Alignment.centerLeft,
+                child: Text("Composition"),
+              )),
+            ]),
+            ListView.builder(
+                shrinkWrap: true,
+                padding: const EdgeInsets.all(5.0),
+                itemCount: backingList.length,
+                itemBuilder: (context, position) {
+                  return backingList[position].menuView(context);
+                }),
+          ],
+        )),
+      ])),
       floatingActionButtonLocation: FloatingActionButtonLocation.centerDocked,
       floatingActionButton: CircularDialMenu.build(context),
       bottomNavigationBar: BottomAppBar(

--- a/lib/Musical-Works/Musical-Compositions.dart
+++ b/lib/Musical-Works/Musical-Compositions.dart
@@ -1,3 +1,4 @@
+import 'package:artifact/bottom_navigation_bar/bottom_button_bar.dart';
 import 'package:flutter/material.dart';
 import 'package:artifact/Musical-Works/Composition.dart';
 import 'package:artifact/Musical-Works/CompositionsDB.dart';
@@ -19,61 +20,59 @@ class CompScreenState extends State<CompScreen> {
     return Scaffold(
       backgroundColor: const Color.fromRGBO(196, 236, 249, 1),
       body: SafeArea(
-          child: Column(children: <Widget>[
-        const Align(
-          alignment: Alignment.topLeft,
-          child: BackButton(),
-        ),
-        Center(
-            child: Column(
-          mainAxisSize: MainAxisSize.min,
+        child: Column(
           children: <Widget>[
-            Row(children: const <Widget>[
-              SizedBox(width: 125),
-              Expanded(
-                  child: Align(
-                alignment: Alignment.center,
-                child: Text('Works', style: TextStyle(fontSize: 40)),
-              )),
-              SizedBox(width: 115),
-            ]),
-            Row(children: const <Widget>[
-              SizedBox(width: 15),
-              Expanded(
-                  child: Align(
-                alignment: Alignment.centerLeft,
-                child: Text("Composition"),
-              )),
-            ]),
-            ListView.builder(
-                shrinkWrap: true,
-                padding: const EdgeInsets.all(5.0),
-                itemCount: backingList.length,
-                itemBuilder: (context, position) {
-                  return backingList[position].menuView(context);
-                }),
-          ],
-        )),
-      ])),
-      floatingActionButtonLocation: FloatingActionButtonLocation.centerDocked,
-      floatingActionButton: CircularDialMenu.build(context),
-      bottomNavigationBar: BottomAppBar(
-        child: Row(
-          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-          children: [
-            IconButton(
-              onPressed: () => Navigator.pushNamed(context, '/main'),
-              tooltip: 'Home',
-              icon: const Icon(Icons.home, color: Colors.black45),
+            const Align(
+              alignment: Alignment.topLeft,
+              child: BackButton(),
             ),
-            IconButton(
-              onPressed: () => Navigator.pushNamed(context, '/settings'),
-              tooltip: 'Settings',
-              icon: const Icon(Icons.settings, color: Colors.black45),
+            Center(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: <Widget>[
+                  Row(
+                    children: const <Widget>[
+                      SizedBox(width: 125),
+                      Expanded(
+                        child: Align(
+                          alignment: Alignment.center,
+                          child: Text(
+                            'Works',
+                            style: TextStyle(fontSize: 40),
+                          ),
+                        ),
+                      ),
+                      SizedBox(width: 115),
+                    ],
+                  ),
+                  Row(
+                    children: const <Widget>[
+                      SizedBox(width: 15),
+                      Expanded(
+                        child: Align(
+                          alignment: Alignment.centerLeft,
+                          child: Text("Composition"),
+                        ),
+                      ),
+                    ],
+                  ),
+                  ListView.builder(
+                    shrinkWrap: true,
+                    padding: const EdgeInsets.all(5.0),
+                    itemCount: backingList.length,
+                    itemBuilder: (context, position) {
+                      return backingList[position].menuView(context);
+                    },
+                  ),
+                ],
+              ),
             ),
           ],
         ),
       ),
+      floatingActionButtonLocation: FloatingActionButtonLocation.centerDocked,
+      floatingActionButton: CircularDialMenu.build(context),
+      bottomNavigationBar: BottomButtonBar.build(context),
     );
   }
 }

--- a/lib/Musical-Works/Musical-Works-Old.dart
+++ b/lib/Musical-Works/Musical-Works-Old.dart
@@ -1,3 +1,4 @@
+import 'package:artifact/bottom_navigation_bar/bottom_button_bar.dart';
 import 'package:flutter/material.dart';
 import 'package:artifact/bottom_navigation_bar/circular_dial_menu.dart';
 
@@ -108,23 +109,7 @@ class WorksScreen extends StatelessWidget {
       // ),
       floatingActionButtonLocation: FloatingActionButtonLocation.centerDocked,
       floatingActionButton: CircularDialMenu.build(context),
-      bottomNavigationBar: BottomAppBar(
-        child: Row(
-          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-          children: [
-            IconButton(
-              onPressed: () => Navigator.pushNamed(context, '/main'),
-              tooltip: 'Home',
-              icon: const Icon(Icons.home, color: Colors.black45),
-            ),
-            IconButton(
-              onPressed: () => Navigator.pushNamed(context, '/settings'),
-              tooltip: 'Settings',
-              icon: const Icon(Icons.settings, color: Colors.black45),
-            ),
-          ],
-        ),
-      ),
+      bottomNavigationBar: BottomButtonBar.build(context),
     );
   }
 }

--- a/lib/Musical-Works/Musical-Works-Old.dart
+++ b/lib/Musical-Works/Musical-Works-Old.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:artifact/circular_dial_menu.dart';
+import 'package:artifact/bottom_navigation_bar/circular_dial_menu.dart';
 
 class WorksScreen extends StatelessWidget {
   const WorksScreen({super.key});

--- a/lib/Quizzes/Quizzes.dart
+++ b/lib/Quizzes/Quizzes.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:artifact/circular_dial_menu.dart';
+import 'package:artifact/bottom_navigation_bar/circular_dial_menu.dart';
 
 import 'Quizzes/quizDB.dart';
 

--- a/lib/Quizzes/Quizzes.dart
+++ b/lib/Quizzes/Quizzes.dart
@@ -1,3 +1,4 @@
+import 'package:artifact/bottom_navigation_bar/bottom_button_bar.dart';
 import 'package:flutter/material.dart';
 import 'package:artifact/bottom_navigation_bar/circular_dial_menu.dart';
 
@@ -39,23 +40,7 @@ class QuizzesScreen extends StatelessWidget {
       ),
       floatingActionButtonLocation: FloatingActionButtonLocation.centerDocked,
       floatingActionButton: CircularDialMenu.build(context),
-      bottomNavigationBar: BottomAppBar(
-        child: Row(
-          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-          children: [
-            IconButton(
-              onPressed: () => Navigator.pushNamed(context, '/main'),
-              tooltip: 'Home',
-              icon: const Icon(Icons.home, color: Colors.black45),
-            ),
-            IconButton(
-              onPressed: () => Navigator.pushNamed(context, '/settings'),
-              tooltip: 'Settings',
-              icon: const Icon(Icons.settings, color: Colors.black45),
-            ),
-          ],
-        ),
-      ),
+      bottomNavigationBar: BottomButtonBar.build(context),
     );
   }
 }

--- a/lib/Quizzes/Results.dart
+++ b/lib/Quizzes/Results.dart
@@ -1,4 +1,5 @@
 import 'package:artifact/Quizzes/quiz.dart';
+import 'package:artifact/bottom_navigation_bar/bottom_button_bar.dart';
 import 'package:artifact/hive_local_data/quiz_result/quiz_result_db.dart';
 import 'package:artifact/hive_local_data/rewards/rewards_points_db.dart';
 import 'package:flutter/material.dart';
@@ -25,14 +26,20 @@ class ResultsScreen extends StatelessWidget {
     }
     List<Widget> wrongQuestionsDisplay = [];
     for (int i = 0; i < wrongQuestions.length; i++) {
-      wrongQuestionsDisplay
-          .add(Text(quiz.questionList[wrongQuestions[i]].question));
-      wrongQuestionsDisplay.add(SizedBox(height: 20));
+      wrongQuestionsDisplay.add(
+        Text(quiz.questionList[wrongQuestions[i]].question),
+      );
+      wrongQuestionsDisplay.add(
+        SizedBox(height: 20),
+      );
     }
 
     List<Widget> disp = [
       const SizedBox(height: 28),
-      Text(quiz.name, style: const TextStyle(fontSize: 40)),
+      Text(
+        quiz.name,
+        style: const TextStyle(fontSize: 40),
+      ),
       const SizedBox(height: 20),
       Text(
         "Score: " +
@@ -42,7 +49,10 @@ class ResultsScreen extends StatelessWidget {
         style: const TextStyle(fontSize: 30),
       ),
       const SizedBox(height: 20),
-      Text("Questions to review:", style: const TextStyle(fontSize: 20)),
+      Text(
+        "Questions to review:",
+        style: const TextStyle(fontSize: 20),
+      ),
       const SizedBox(height: 20),
     ];
 
@@ -52,29 +62,14 @@ class ResultsScreen extends StatelessWidget {
       backgroundColor: const Color.fromRGBO(225, 255, 195, 1),
       body: SingleChildScrollView(
         child: Container(
-            margin: const EdgeInsets.all(24),
-            alignment: Alignment.topCenter,
-            child: Column(mainAxisSize: MainAxisSize.min, children: disp)),
+          margin: const EdgeInsets.all(24),
+          alignment: Alignment.topCenter,
+          child: Column(mainAxisSize: MainAxisSize.min, children: disp),
+        ),
       ),
       floatingActionButtonLocation: FloatingActionButtonLocation.centerDocked,
       floatingActionButton: CircularDialMenu.build(context),
-      bottomNavigationBar: BottomAppBar(
-        child: Row(
-          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-          children: [
-            IconButton(
-              onPressed: () => Navigator.pushNamed(context, '/main'),
-              tooltip: 'Home',
-              icon: const Icon(Icons.home, color: Colors.black45),
-            ),
-            IconButton(
-              onPressed: () => Navigator.pushNamed(context, '/settings'),
-              tooltip: 'Settings',
-              icon: const Icon(Icons.settings, color: Colors.black45),
-            ),
-          ],
-        ),
-      ),
+      bottomNavigationBar: BottomButtonBar.build(context),
     );
   }
 }

--- a/lib/Quizzes/Results.dart
+++ b/lib/Quizzes/Results.dart
@@ -2,7 +2,7 @@ import 'package:artifact/Quizzes/quiz.dart';
 import 'package:artifact/hive_local_data/quiz_result/quiz_result_db.dart';
 import 'package:artifact/hive_local_data/rewards/rewards_points_db.dart';
 import 'package:flutter/material.dart';
-import 'package:artifact/circular_dial_menu.dart';
+import 'package:artifact/bottom_navigation_bar/circular_dial_menu.dart';
 
 class ResultsScreen extends StatelessWidget {
   final List<String> answers;

--- a/lib/Quizzes/Results.dart
+++ b/lib/Quizzes/Results.dart
@@ -1,12 +1,16 @@
 import 'package:artifact/Quizzes/quiz.dart';
+import 'package:artifact/hive_local_data/quiz_result/quiz_result_db.dart';
+import 'package:artifact/hive_local_data/rewards/rewards_points_db.dart';
 import 'package:flutter/material.dart';
 import 'package:artifact/circular_dial_menu.dart';
 
 class ResultsScreen extends StatelessWidget {
   final List<String> answers;
   final Quiz quiz;
+  final _resultsDatabase = QuizResultDatabase();
+  final _rewardsDatabase = RewardPointsDatabase();
 
-  const ResultsScreen({required this.answers, required this.quiz, super.key});
+  ResultsScreen({required this.answers, required this.quiz, super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -21,7 +25,8 @@ class ResultsScreen extends StatelessWidget {
     }
     List<Widget> wrongQuestionsDisplay = [];
     for (int i = 0; i < wrongQuestions.length; i++) {
-      wrongQuestionsDisplay.add(Text(quiz.questionList[wrongQuestions[i]].question));
+      wrongQuestionsDisplay
+          .add(Text(quiz.questionList[wrongQuestions[i]].question));
       wrongQuestionsDisplay.add(SizedBox(height: 20));
     }
 
@@ -29,8 +34,12 @@ class ResultsScreen extends StatelessWidget {
       const SizedBox(height: 28),
       Text(quiz.name, style: const TextStyle(fontSize: 40)),
       const SizedBox(height: 20),
-      Text("Score: " + score.toString() + "/" + quiz.questionList.length.toString(),
-      style: const TextStyle(fontSize: 30),
+      Text(
+        "Score: " +
+            score.toString() +
+            "/" +
+            quiz.questionList.length.toString(),
+        style: const TextStyle(fontSize: 30),
       ),
       const SizedBox(height: 20),
       Text("Questions to review:", style: const TextStyle(fontSize: 20)),
@@ -40,17 +49,13 @@ class ResultsScreen extends StatelessWidget {
     disp.addAll(wrongQuestionsDisplay);
 
     return Scaffold(
-        backgroundColor: const Color.fromRGBO(225, 255, 195, 1),
-        body: SingleChildScrollView(
-          child: Container(
+      backgroundColor: const Color.fromRGBO(225, 255, 195, 1),
+      body: SingleChildScrollView(
+        child: Container(
             margin: const EdgeInsets.all(24),
             alignment: Alignment.topCenter,
-              child: Column(mainAxisSize: MainAxisSize.min,
-                children: disp
-            )
-          ),
-        ),
-
+            child: Column(mainAxisSize: MainAxisSize.min, children: disp)),
+      ),
       floatingActionButtonLocation: FloatingActionButtonLocation.centerDocked,
       floatingActionButton: CircularDialMenu.build(context),
       bottomNavigationBar: BottomAppBar(
@@ -70,7 +75,6 @@ class ResultsScreen extends StatelessWidget {
           ],
         ),
       ),
-
     );
   }
 }

--- a/lib/Quizzes/quiz.dart
+++ b/lib/Quizzes/quiz.dart
@@ -1,7 +1,7 @@
 import 'package:artifact/Quizzes/QuestionSemantics/quiz_question.dart';
 import 'package:artifact/Quizzes/start_screen.dart';
 import 'package:flutter/material.dart';
-import 'package:artifact/circular_dial_menu.dart';
+import 'package:artifact/bottom_navigation_bar/circular_dial_menu.dart';
 
 import 'QuestionSemantics/quiz_question.dart';
 
@@ -20,7 +20,8 @@ class Quiz {
 
   TextButton menuView(context) {
     return TextButton(
-      style: ButtonStyle(backgroundColor: MaterialStateProperty.all(Colors.blueGrey[100])),
+      style: ButtonStyle(
+          backgroundColor: MaterialStateProperty.all(Colors.blueGrey[100])),
       onPressed: () {
         Navigator.push(
           context,
@@ -38,7 +39,8 @@ class Quiz {
         Expanded(
           child: Align(
             alignment: Alignment.centerRight,
-            child: Text('ScorePlaceholder'), //Maybe style it to different colors based on x/x, 0/x, or something inbetween?
+            child: Text(
+                'ScorePlaceholder'), //Maybe style it to different colors based on x/x, 0/x, or something inbetween?
           ),
         )
       ]),

--- a/lib/Quizzes/start_screen.dart
+++ b/lib/Quizzes/start_screen.dart
@@ -1,6 +1,6 @@
 import 'package:artifact/Quizzes/quiz.dart';
 import 'package:flutter/material.dart';
-import 'package:artifact/circular_dial_menu.dart';
+import 'package:artifact/bottom_navigation_bar/circular_dial_menu.dart';
 import 'package:artifact/Musical-Terms/Term.dart';
 import '../main.dart';
 import 'QuestionSemantics/question_screen.dart';
@@ -38,8 +38,10 @@ class StartScreen extends StatelessWidget {
                     onPressed: () {
                       Navigator.push(
                         context,
-                        MaterialPageRoute(builder: (context) => QuestionScreen(quiz: quiz)),
-                      );},
+                        MaterialPageRoute(
+                            builder: (context) => QuestionScreen(quiz: quiz)),
+                      );
+                    },
                     child: const Text('Start!',
                         style: TextStyle(color: Colors.black, fontSize: 30)),
                   ),

--- a/lib/Quizzes/start_screen.dart
+++ b/lib/Quizzes/start_screen.dart
@@ -1,4 +1,5 @@
 import 'package:artifact/Quizzes/quiz.dart';
+import 'package:artifact/bottom_navigation_bar/bottom_button_bar.dart';
 import 'package:flutter/material.dart';
 import 'package:artifact/bottom_navigation_bar/circular_dial_menu.dart';
 import 'package:artifact/Musical-Terms/Term.dart';
@@ -25,27 +26,39 @@ class StartScreen extends StatelessWidget {
             Center(
               child: Padding(
                 padding: const EdgeInsets.all(40),
-                child:
-                    Column(mainAxisSize: MainAxisSize.min, children: <Widget>[
-                  Text(quiz.name, style: const TextStyle(fontSize: 40)),
-                  const SizedBox(height: 20),
-                  Text(quiz.desc, style: const TextStyle(fontSize: 20)),
-                  const SizedBox(height: 20),
-                  TextButton(
-                    style: ButtonStyle(
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: <Widget>[
+                    Text(
+                      quiz.name,
+                      style: const TextStyle(fontSize: 40),
+                    ),
+                    const SizedBox(height: 20),
+                    Text(
+                      quiz.desc,
+                      style: const TextStyle(fontSize: 20),
+                    ),
+                    const SizedBox(height: 20),
+                    TextButton(
+                      style: ButtonStyle(
                         backgroundColor:
-                            MaterialStateProperty.all(Colors.green[600])),
-                    onPressed: () {
-                      Navigator.push(
-                        context,
-                        MaterialPageRoute(
-                            builder: (context) => QuestionScreen(quiz: quiz)),
-                      );
-                    },
-                    child: const Text('Start!',
-                        style: TextStyle(color: Colors.black, fontSize: 30)),
-                  ),
-                ]),
+                            MaterialStateProperty.all(Colors.green[600]),
+                      ),
+                      onPressed: () {
+                        Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            builder: (context) => QuestionScreen(quiz: quiz),
+                          ),
+                        );
+                      },
+                      child: const Text(
+                        'Start!',
+                        style: TextStyle(color: Colors.black, fontSize: 30),
+                      ),
+                    ),
+                  ],
+                ),
               ),
             )
           ],
@@ -53,24 +66,7 @@ class StartScreen extends StatelessWidget {
       ),
       floatingActionButtonLocation: FloatingActionButtonLocation.centerDocked,
       floatingActionButton: CircularDialMenu.build(context),
-      bottomNavigationBar: BottomAppBar(
-        child: Row(
-          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-          children: [
-            IconButton(
-              onPressed: () => Navigator.push(context,
-                  MaterialPageRoute(builder: (context) => const MainScreen())),
-              tooltip: 'Home',
-              icon: const Icon(Icons.home, color: Colors.black45),
-            ),
-            IconButton(
-              onPressed: () => Navigator.pushNamed(context, '/settings'),
-              tooltip: 'Settings',
-              icon: const Icon(Icons.settings, color: Colors.black45),
-            ),
-          ],
-        ),
-      ),
+      bottomNavigationBar: BottomButtonBar.build(context),
     );
   }
 }

--- a/lib/bottom_button_bar.dart
+++ b/lib/bottom_button_bar.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+
+class BottomButtonBar {
+  static Widget build(context) {
+    return BottomAppBar(
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+        children: [
+          IconButton(
+            onPressed: () => Navigator.pushNamed(context, '/main'),
+            tooltip: 'Home',
+            icon: const Icon(Icons.home, color: Colors.black45),
+          ),
+          IconButton(
+            onPressed: () => Navigator.pushNamed(context, '/settings'),
+            tooltip: 'Settings',
+            icon: const Icon(Icons.settings, color: Colors.black45),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/bottom_navigation_bar/bottom_button_bar.dart
+++ b/lib/bottom_navigation_bar/bottom_button_bar.dart
@@ -7,7 +7,8 @@ class BottomButtonBar {
         mainAxisAlignment: MainAxisAlignment.spaceEvenly,
         children: [
           IconButton(
-            onPressed: () => Navigator.pushNamed(context, '/main'),
+            onPressed: () => Navigator.pushNamedAndRemoveUntil(
+                context, '/main', (route) => false),
             tooltip: 'Home',
             icon: const Icon(Icons.home, color: Colors.black45),
           ),

--- a/lib/bottom_navigation_bar/bottom_button_bar.dart
+++ b/lib/bottom_navigation_bar/bottom_button_bar.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+/// Bar that holds shortcut buttons to different menus
 class BottomButtonBar {
   static Widget build(context) {
     return BottomAppBar(

--- a/lib/bottom_navigation_bar/circular_dial_menu.dart
+++ b/lib/bottom_navigation_bar/circular_dial_menu.dart
@@ -1,4 +1,3 @@
-
 import 'package:flutter/material.dart';
 import 'package:circular_menu/circular_menu.dart';
 import 'dart:math' as math;

--- a/lib/bottom_navigation_bar/circular_dial_menu.dart
+++ b/lib/bottom_navigation_bar/circular_dial_menu.dart
@@ -1,3 +1,4 @@
+
 import 'package:flutter/material.dart';
 import 'package:circular_menu/circular_menu.dart';
 import 'dart:math' as math;

--- a/lib/hive_local_data/quiz_result/quiz_result_db.dart
+++ b/lib/hive_local_data/quiz_result/quiz_result_db.dart
@@ -1,6 +1,6 @@
 import 'package:hive_flutter/hive_flutter.dart';
 
-/// Datebase that holds all of the quiz results
+/// Datebase that holds all of the quiz results.
 class QuizResultDatabase {
   /// Each entry is a name with its score
   List resultList = [];

--- a/lib/hive_local_data/rewards/rewards_points_db.dart
+++ b/lib/hive_local_data/rewards/rewards_points_db.dart
@@ -1,0 +1,32 @@
+import 'package:hive_flutter/hive_flutter.dart';
+
+/// Datebase that holds whether the user has unlocked a reward
+class RewardPointsDatabase {
+  /// Key for the RewardsDatabase
+  String _rewardPointsDataKey = "REWARDPOINTS";
+
+  /// The amount of rewards points the user has
+  int rewardPoints = 0;
+
+  final _userBox = Hive.box('userBox');
+
+  /// Run this method if 1st time running the app
+  void createInitialData() {
+    _userBox.put(_rewardPointsDataKey, rewardPoints);
+  }
+
+  /// Load data from rewards database.
+  void loadData() {
+    rewardPoints = _userBox.get(_rewardPointsDataKey);
+  }
+
+  /// Update reward points.
+  void updateData() {
+    _userBox.put(_rewardPointsDataKey, rewardPoints);
+  }
+
+  /// Gets the rewards list
+  List getRewardPoints() {
+    return _userBox.get(_rewardPointsDataKey);
+  }
+}

--- a/lib/hive_local_data/rewards/rewards_points_db.dart
+++ b/lib/hive_local_data/rewards/rewards_points_db.dart
@@ -1,16 +1,16 @@
 import 'package:hive_flutter/hive_flutter.dart';
 
-/// Datebase that holds whether the user has unlocked a reward
+/// Datebase that holds the user's rewards points.
 class RewardPointsDatabase {
   /// Key for the RewardsDatabase
   String _rewardPointsDataKey = "REWARDPOINTS";
 
-  /// The amount of rewards points the user has
+  /// The amount of rewards points the user has.
   int rewardPoints = 0;
 
   final _userBox = Hive.box('userBox');
 
-  /// Run this method if 1st time running the app
+  /// Run this method if 1st time running the app.
   void createInitialData() {
     _userBox.put(_rewardPointsDataKey, rewardPoints);
   }
@@ -25,7 +25,7 @@ class RewardPointsDatabase {
     _userBox.put(_rewardPointsDataKey, rewardPoints);
   }
 
-  /// Gets the rewards list
+  /// Gets the rewards points.
   List getRewardPoints() {
     return _userBox.get(_rewardPointsDataKey);
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:artifact/Quizzes/Results.dart';
+import 'package:artifact/bottom_button_bar.dart';
 import 'package:artifact/settings/about_screen.dart';
 import 'package:artifact/settings/help_menu.dart';
 import 'package:artifact/settings/help_menus/composers_help.dart';
@@ -195,23 +196,7 @@ class MainScreen extends StatelessWidget {
       ),
       floatingActionButtonLocation: FloatingActionButtonLocation.centerDocked,
       floatingActionButton: CircularDialMenu.build(context),
-      bottomNavigationBar: BottomAppBar(
-        child: Row(
-          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-          children: [
-            IconButton(
-              onPressed: () {},
-              tooltip: 'Home',
-              icon: const Icon(Icons.home, color: Colors.black45),
-            ),
-            IconButton(
-              onPressed: () => Navigator.pushNamed(context, '/settings'),
-              tooltip: 'Settings',
-              icon: const Icon(Icons.settings, color: Colors.black45),
-            ),
-          ],
-        ),
-      ),
+      bottomNavigationBar: BottomButtonBar.build(context),
     );
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,5 @@
 import 'package:artifact/Quizzes/Results.dart';
-import 'package:artifact/bottom_button_bar.dart';
+import 'package:artifact/bottom_navigation_bar/bottom_button_bar.dart';
 import 'package:artifact/settings/about_screen.dart';
 import 'package:artifact/settings/help_menu.dart';
 import 'package:artifact/settings/help_menus/composers_help.dart';
@@ -15,7 +15,7 @@ import '/Listen/Listen.dart';
 import '/Musical-Works/Musical-Compositions.dart';
 import '/Quizzes/Quizzes.dart';
 import 'package:artifact/settings/settings_menu.dart';
-import 'circular_dial_menu.dart';
+import 'bottom_navigation_bar/circular_dial_menu.dart';
 import '/Composers/Beethoven.dart';
 import '/Composers/Mozart.dart';
 import '/Composers/Bach.dart';

--- a/lib/rewards/rewards_screen.dart
+++ b/lib/rewards/rewards_screen.dart
@@ -1,10 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:artifact/circular_dial_menu.dart';
 
-import 'Quizzes/quizDB.dart';
+// FIXME: Might need to change to StatefulWidget depending on implementation
+//  redeeming rewards
 
-class QuizzesScreen extends StatelessWidget {
-  const QuizzesScreen({super.key});
+/// Screen for the rewards page
+class RewardsScreen extends StatelessWidget {
+  const RewardsScreen({super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -23,13 +25,7 @@ class QuizzesScreen extends StatelessWidget {
                 child: Padding(
                   padding: const EdgeInsets.all(40),
                   child: Column(
-                    children: <Widget>[
-                      const Text('Quizzes', style: TextStyle(fontSize: 40)),
-                      const SizedBox(height: 30),
-                      QuizDB.quiz1.menuView(context),
-                      QuizDB.quiz2.menuView(context),
-                      //ADD OTHER QUIZZES HERE LIKE SO
-                    ],
+                    children: <Widget>[],
                   ),
                 ),
               ),

--- a/lib/rewards/rewards_screen.dart
+++ b/lib/rewards/rewards_screen.dart
@@ -1,3 +1,4 @@
+import 'package:artifact/bottom_navigation_bar/bottom_button_bar.dart';
 import 'package:flutter/material.dart';
 import 'package:artifact/bottom_navigation_bar/circular_dial_menu.dart';
 
@@ -35,23 +36,7 @@ class RewardsScreen extends StatelessWidget {
       ),
       floatingActionButtonLocation: FloatingActionButtonLocation.centerDocked,
       floatingActionButton: CircularDialMenu.build(context),
-      bottomNavigationBar: BottomAppBar(
-        child: Row(
-          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-          children: [
-            IconButton(
-              onPressed: () => Navigator.pushNamed(context, '/main'),
-              tooltip: 'Home',
-              icon: const Icon(Icons.home, color: Colors.black45),
-            ),
-            IconButton(
-              onPressed: () => Navigator.pushNamed(context, '/settings'),
-              tooltip: 'Settings',
-              icon: const Icon(Icons.settings, color: Colors.black45),
-            ),
-          ],
-        ),
-      ),
+      bottomNavigationBar: BottomButtonBar.build(context),
     );
   }
 }

--- a/lib/rewards/rewards_screen.dart
+++ b/lib/rewards/rewards_screen.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:artifact/circular_dial_menu.dart';
+import 'package:artifact/bottom_navigation_bar/circular_dial_menu.dart';
 
 // FIXME: Might need to change to StatefulWidget depending on implementation
 //  redeeming rewards

--- a/lib/settings/about_screen.dart
+++ b/lib/settings/about_screen.dart
@@ -5,8 +5,9 @@ class AboutScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final ButtonStyle style =
-        ElevatedButton.styleFrom(textStyle: const TextStyle(fontSize: 20));
+    final ButtonStyle style = ElevatedButton.styleFrom(
+      textStyle: const TextStyle(fontSize: 20),
+    );
     return Scaffold(
       backgroundColor: const Color.fromRGBO(255, 214, 153, 1),
       body: SafeArea(
@@ -21,7 +22,9 @@ class AboutScreen extends StatelessWidget {
               child: Column(
                 mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                 children: [
-                  Padding(padding: const EdgeInsets.all(40)),
+                  Padding(
+                    padding: const EdgeInsets.all(40),
+                  ),
                   // Text for developing team
                   RichText(
                     text: const TextSpan(
@@ -31,12 +34,15 @@ class AboutScreen extends StatelessWidget {
                           '\n- Alex Laney\n- Jacob Singer\n- Sanjeev Viswan',
                     ),
                   ),
-                  Padding(padding: const EdgeInsets.all(40)),
+                  Padding(
+                    padding: const EdgeInsets.all(40),
+                  ),
                   // Creates the button for licensing agreements
                   ElevatedButton(
-                      style: style,
-                      onPressed: () => Navigator.pushNamed(context, '/license'),
-                      child: const Text('License'))
+                    style: style,
+                    onPressed: () => Navigator.pushNamed(context, '/license'),
+                    child: const Text('License'),
+                  ),
                 ],
               ),
             ),

--- a/lib/settings/help_menu.dart
+++ b/lib/settings/help_menu.dart
@@ -1,3 +1,4 @@
+import 'package:artifact/bottom_button_bar.dart';
 import 'package:flutter/material.dart';
 import 'package:artifact/circular_dial_menu.dart';
 
@@ -18,85 +19,85 @@ class HelpScreen extends StatelessWidget {
               alignment: Alignment.topLeft,
               child: BackButton(),
             ),
-        Container(
-          margin: const EdgeInsets.only(bottom: 100.0),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-            children: <Widget>[
-              Padding(padding: const EdgeInsets.all(30),
-              child: ElevatedButton(
-                style: style.copyWith(backgroundColor:
-                    MaterialStateProperty.resolveWith((states) {
-                  return Color.fromRGBO(255, 246, 167, 1);
-                })),
-                onPressed: () {
-                  Navigator.pushNamed(context, '/composersHelp');
-                },
-                child: const Text('Composers'),
+            Container(
+              margin: const EdgeInsets.only(bottom: 100.0),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                children: <Widget>[
+                  Padding(
+                    padding: const EdgeInsets.all(30),
+                    child: ElevatedButton(
+                      style: style.copyWith(
+                        backgroundColor: MaterialStateProperty.resolveWith(
+                          (states) {
+                            return Color.fromRGBO(255, 246, 167, 1);
+                          },
+                        ),
+                      ),
+                      onPressed: () {
+                        Navigator.pushNamed(context, '/composersHelp');
+                      },
+                      child: const Text('Composers'),
+                    ),
+                  ),
+                  Padding(
+                    padding: const EdgeInsets.all(30),
+                    child: ElevatedButton(
+                      style: style.copyWith(
+                        backgroundColor: MaterialStateProperty.resolveWith(
+                          (states) {
+                            return Color.fromRGBO(239, 199, 199, 1);
+                          },
+                        ),
+                      ),
+                      onPressed: () {
+                        Navigator.pushNamed(context, '/termsHelp');
+                      },
+                      child: const Text('Musical Terms'),
+                    ),
+                  ),
+                  Padding(
+                    padding: const EdgeInsets.all(30),
+                    child: ElevatedButton(
+                      style: style.copyWith(
+                        backgroundColor: MaterialStateProperty.resolveWith(
+                          (states) {
+                            return Color.fromRGBO(196, 236, 249, 1);
+                          },
+                        ),
+                      ),
+                      onPressed: () {
+                        Navigator.pushNamed(context, '/worksHelp');
+                      },
+                      child: const Text('Works'),
+                    ),
+                  ),
+                  Padding(
+                    padding: const EdgeInsets.all(30),
+                    child: ElevatedButton(
+                      style: style.copyWith(
+                        backgroundColor: MaterialStateProperty.resolveWith(
+                          (states) {
+                            return Color.fromRGBO(225, 255, 195, 1);
+                          },
+                        ),
+                      ),
+                      onPressed: () {
+                        Navigator.pushNamed(context, '/quizzesHelp');
+                      },
+                      child: const Text('Quizzes'),
+                    ),
+                  ),
+                ],
               ),
-              ),
-              Padding(padding: const EdgeInsets.all(30),
-              child: ElevatedButton(
-                style: style.copyWith(backgroundColor:
-                    MaterialStateProperty.resolveWith((states) {
-                  return Color.fromRGBO(239, 199, 199, 1);
-                })),
-                onPressed: () {
-                  Navigator.pushNamed(context, '/termsHelp');
-                },
-                child: const Text('Musical Terms'),
-              ),
-              ),
-              Padding(padding: const EdgeInsets.all(30),
-              child: ElevatedButton(
-                style: style.copyWith(backgroundColor:
-                    MaterialStateProperty.resolveWith((states) {
-                  return Color.fromRGBO(196, 236, 249, 1);
-                })),
-                onPressed: () {
-                  Navigator.pushNamed(context, '/worksHelp');
-                },
-                child: const Text('Works'),
-              ),
-              ),
-              Padding(padding: const EdgeInsets.all(30),
-              child: ElevatedButton(
-                style: style.copyWith(backgroundColor:
-                    MaterialStateProperty.resolveWith((states) {
-                  return Color.fromRGBO(225, 255, 195, 1);
-                })),
-                onPressed: () {
-                  Navigator.pushNamed(context, '/quizzesHelp');
-                },
-                child: const Text('Quizzes'),
-              ),
-              ),
-            ],
-          ),
-        ),
+            ),
           ],
-      ),
+        ),
       ),
       floatingActionButtonLocation: FloatingActionButtonLocation.centerDocked,
-        floatingActionButton: CircularDialMenu.build(context),
-        bottomNavigationBar: BottomAppBar(
-          child: Row(
-            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-            children: [
-              IconButton(
-                onPressed: () => Navigator.pushNamed(context, '/main'),
-                tooltip: 'Home',
-                icon: const Icon(Icons.home, color: Colors.black45),
-              ),
-              IconButton(
-                onPressed: () => Navigator.pushNamed(context, '/settings'),
-                tooltip: 'Settings',
-                icon: const Icon(Icons.settings, color: Colors.black45),
-              ),
-          ],
-        ),
-      ),
+      floatingActionButton: CircularDialMenu.build(context),
+      bottomNavigationBar: BottomButtonBar.build(context),
     );
   }
 }

--- a/lib/settings/help_menu.dart
+++ b/lib/settings/help_menu.dart
@@ -1,6 +1,6 @@
-import 'package:artifact/bottom_button_bar.dart';
+import 'package:artifact/bottom_navigation_bar/bottom_button_bar.dart';
 import 'package:flutter/material.dart';
-import 'package:artifact/circular_dial_menu.dart';
+import 'package:artifact/bottom_navigation_bar/circular_dial_menu.dart';
 
 class HelpScreen extends StatelessWidget {
   const HelpScreen({super.key});

--- a/lib/settings/help_menus/composers_help.dart
+++ b/lib/settings/help_menus/composers_help.dart
@@ -1,7 +1,7 @@
 import 'package:circular_menu/circular_menu.dart';
 import 'package:flutter/material.dart';
 
-import '../../circular_dial_menu.dart';
+import '../../bottom_navigation_bar/circular_dial_menu.dart';
 
 class ComposersHelpScreen extends StatelessWidget {
   const ComposersHelpScreen({super.key});
@@ -19,16 +19,16 @@ class ComposersHelpScreen extends StatelessWidget {
               child: BackButton(),
             ),
             const Text('Composers Help', style: TextStyle(fontSize: 40)),
-        Padding(
-          padding: const EdgeInsets.all(40),
-            child: RichText(
-              textAlign: TextAlign.justify,
-              text: const TextSpan(
-                text: 'The composers page contains biographies about various famous composers who have influenced '
-                    'the development of classical music. Each page covers the upbringing and career of a composer and gives'
-                    ' readers insight on how they developed as a musician.',
-                style:
-                  const TextStyle(fontSize: 20, color: Colors.black),
+            Padding(
+              padding: const EdgeInsets.all(40),
+              child: RichText(
+                textAlign: TextAlign.justify,
+                text: const TextSpan(
+                  text:
+                      'The composers page contains biographies about various famous composers who have influenced '
+                      'the development of classical music. Each page covers the upbringing and career of a composer and gives'
+                      ' readers insight on how they developed as a musician.',
+                  style: const TextStyle(fontSize: 20, color: Colors.black),
                 ),
               ),
             ),

--- a/lib/settings/help_menus/composers_help.dart
+++ b/lib/settings/help_menus/composers_help.dart
@@ -1,3 +1,4 @@
+import 'package:artifact/bottom_navigation_bar/bottom_button_bar.dart';
 import 'package:circular_menu/circular_menu.dart';
 import 'package:flutter/material.dart';
 
@@ -37,24 +38,7 @@ class ComposersHelpScreen extends StatelessWidget {
       ),
       floatingActionButtonLocation: FloatingActionButtonLocation.centerDocked,
       floatingActionButton: CircularDialMenu.build(context),
-      bottomNavigationBar: BottomAppBar(
-        child: Row(
-          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-          children: [
-            IconButton(
-              onPressed: () => Navigator.pushNamedAndRemoveUntil(
-                  context, '/', (route) => false),
-              tooltip: 'Home',
-              icon: const Icon(Icons.home, color: Colors.black45),
-            ),
-            IconButton(
-              onPressed: () {},
-              tooltip: 'Settings',
-              icon: const Icon(Icons.settings, color: Colors.black45),
-            ),
-          ],
-        ),
-      ),
+      bottomNavigationBar: BottomButtonBar.build(context),
     );
   }
 }

--- a/lib/settings/help_menus/musical_terms_help.dart
+++ b/lib/settings/help_menus/musical_terms_help.dart
@@ -1,7 +1,7 @@
 import 'package:circular_menu/circular_menu.dart';
 import 'package:flutter/material.dart';
 
-import '../../circular_dial_menu.dart';
+import '../../bottom_navigation_bar/circular_dial_menu.dart';
 
 class MusicalTermsHelpScreen extends StatelessWidget {
   const MusicalTermsHelpScreen({super.key});

--- a/lib/settings/help_menus/musical_terms_help.dart
+++ b/lib/settings/help_menus/musical_terms_help.dart
@@ -1,3 +1,4 @@
+import 'package:artifact/bottom_navigation_bar/bottom_button_bar.dart';
 import 'package:circular_menu/circular_menu.dart';
 import 'package:flutter/material.dart';
 
@@ -59,24 +60,7 @@ class MusicalTermsHelpScreen extends StatelessWidget {
       ])),
       floatingActionButtonLocation: FloatingActionButtonLocation.centerDocked,
       floatingActionButton: CircularDialMenu.build(context),
-      bottomNavigationBar: BottomAppBar(
-        child: Row(
-          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-          children: [
-            IconButton(
-              onPressed: () => Navigator.pushNamedAndRemoveUntil(
-                  context, '/main', (route) => false),
-              tooltip: 'Home',
-              icon: const Icon(Icons.home, color: Colors.black45),
-            ),
-            IconButton(
-              onPressed: () {},
-              tooltip: 'Settings',
-              icon: const Icon(Icons.settings, color: Colors.black45),
-            ),
-          ],
-        ),
-      ),
+      bottomNavigationBar: BottomButtonBar.build(context),
     );
   }
 }

--- a/lib/settings/help_menus/quizzes_help.dart
+++ b/lib/settings/help_menus/quizzes_help.dart
@@ -1,7 +1,7 @@
 import 'package:circular_menu/circular_menu.dart';
 import 'package:flutter/material.dart';
 
-import '../../circular_dial_menu.dart';
+import '../../bottom_navigation_bar/circular_dial_menu.dart';
 
 class QuizzesHelpScreen extends StatelessWidget {
   const QuizzesHelpScreen({super.key});
@@ -46,10 +46,10 @@ class QuizzesHelpScreen extends StatelessWidget {
                           const TextSpan(
                               text:
                                   ' icon from the menu at the bottom of the screen, or from the main menu, is where you can test what you\'ve learned. Some quizzes might require you to do your own research outside of the app. Have fun, and try to get the highest score!'),
-                            ])))
-              ]),
-            )
-          ])),
+                        ])))
+          ]),
+        )
+      ])),
       floatingActionButtonLocation: FloatingActionButtonLocation.centerDocked,
       floatingActionButton: CircularDialMenu.build(context),
       bottomNavigationBar: BottomAppBar(

--- a/lib/settings/help_menus/quizzes_help.dart
+++ b/lib/settings/help_menus/quizzes_help.dart
@@ -1,3 +1,4 @@
+import 'package:artifact/bottom_navigation_bar/bottom_button_bar.dart';
 import 'package:circular_menu/circular_menu.dart';
 import 'package:flutter/material.dart';
 
@@ -52,24 +53,7 @@ class QuizzesHelpScreen extends StatelessWidget {
       ])),
       floatingActionButtonLocation: FloatingActionButtonLocation.centerDocked,
       floatingActionButton: CircularDialMenu.build(context),
-      bottomNavigationBar: BottomAppBar(
-        child: Row(
-          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-          children: [
-            IconButton(
-              onPressed: () => Navigator.pushNamedAndRemoveUntil(
-                  context, '/main', (route) => false),
-              tooltip: 'Home',
-              icon: const Icon(Icons.home, color: Colors.black45),
-            ),
-            IconButton(
-              onPressed: () {},
-              tooltip: 'Settings',
-              icon: const Icon(Icons.settings, color: Colors.black45),
-            ),
-          ],
-        ),
-      ),
+      bottomNavigationBar: BottomButtonBar.build(context),
     );
   }
 }

--- a/lib/settings/help_menus/works_help.dart
+++ b/lib/settings/help_menus/works_help.dart
@@ -1,8 +1,10 @@
 import 'package:circular_menu/circular_menu.dart';
 import 'package:flutter/material.dart';
 
-import '../../circular_dial_menu.dart';
+import '../../bottom_navigation_bar/circular_dial_menu.dart';
+
 const int iconColor = 300;
+
 class WorksHelpScreen extends StatelessWidget {
   const WorksHelpScreen({super.key});
 
@@ -12,63 +14,59 @@ class WorksHelpScreen extends StatelessWidget {
       backgroundColor: const Color.fromRGBO(255, 214, 153, 1),
       body: SafeArea(
           child: Column(children: <Widget>[
-            const Align(
-              alignment: Alignment.topLeft,
-              child: BackButton(),
-            ),
-            Center(
-              child: Column(children: <Widget>[
-                const Text('Musical Works Help', style: TextStyle(fontSize:
-                40)),
-                Padding(
-                    padding: const EdgeInsets.all(40),
-                    child: RichText(
-                        textAlign: TextAlign.justify,
-                        text: TextSpan(
-                            text:
-                            'The Musical Works page, which you can access '
-                                'with the ',
-                            style:
+        const Align(
+          alignment: Alignment.topLeft,
+          child: BackButton(),
+        ),
+        Center(
+          child: Column(children: <Widget>[
+            const Text('Musical Works Help', style: TextStyle(fontSize: 40)),
+            Padding(
+                padding: const EdgeInsets.all(40),
+                child: RichText(
+                    textAlign: TextAlign.justify,
+                    text: TextSpan(
+                        text: 'The Musical Works page, which you can access '
+                            'with the ',
+                        style:
                             const TextStyle(fontSize: 20, color: Colors.black),
-                            children: <InlineSpan>[
-                              WidgetSpan(
-                                child: CircularMenuItem(
-                                  padding: 5,
-                                  margin: 0,
-                                  badgeRadius: 10,
-                                  iconSize: 10,
-                                  boxShadow: const [],
-                                  color: Colors.blue[iconColor],
-                                  icon: Icons.music_note,
-                                  iconColor: Colors.black,
-                                  onTap: () =>
-                                      Navigator.pushNamed(context, '/works'),
-                                ),
-                              ),
-                              const TextSpan(
-                                  text:
-                                  ' icon from the menu at the bottom of the '
-                                      'screen, or from the main menu, is where '
-                                      'you can find the different songs in the '
-                                      'app! Tap on any of their names to be '
-                                      'taken to their page, where you can read '
-                                      'up about the stories of their creations,'
-                                      'and learn about how those older musical '
-                                      'works compare to modern ones! Also, if '
-                                      'you see any'),
-                              const TextSpan(
-                                  text: ' blue ',
-                                  style: TextStyle(
-                                      fontSize: 20, color: Colors.lightBlue)),
-                              const TextSpan(
-                                  text:
-                                  'words that you don\'t recognize, click on '
-                                      'them and you will be brought to a page '
-                                      'explaining what they mean!'),
-                            ])))
-              ]),
-            )
-          ])),
+                        children: <InlineSpan>[
+                          WidgetSpan(
+                            child: CircularMenuItem(
+                              padding: 5,
+                              margin: 0,
+                              badgeRadius: 10,
+                              iconSize: 10,
+                              boxShadow: const [],
+                              color: Colors.blue[iconColor],
+                              icon: Icons.music_note,
+                              iconColor: Colors.black,
+                              onTap: () =>
+                                  Navigator.pushNamed(context, '/works'),
+                            ),
+                          ),
+                          const TextSpan(
+                              text: ' icon from the menu at the bottom of the '
+                                  'screen, or from the main menu, is where '
+                                  'you can find the different songs in the '
+                                  'app! Tap on any of their names to be '
+                                  'taken to their page, where you can read '
+                                  'up about the stories of their creations,'
+                                  'and learn about how those older musical '
+                                  'works compare to modern ones! Also, if '
+                                  'you see any'),
+                          const TextSpan(
+                              text: ' blue ',
+                              style: TextStyle(
+                                  fontSize: 20, color: Colors.lightBlue)),
+                          const TextSpan(
+                              text: 'words that you don\'t recognize, click on '
+                                  'them and you will be brought to a page '
+                                  'explaining what they mean!'),
+                        ])))
+          ]),
+        )
+      ])),
       floatingActionButtonLocation: FloatingActionButtonLocation.centerDocked,
       floatingActionButton: CircularDialMenu.build(context),
       bottomNavigationBar: BottomAppBar(

--- a/lib/settings/help_menus/works_help.dart
+++ b/lib/settings/help_menus/works_help.dart
@@ -1,3 +1,4 @@
+import 'package:artifact/bottom_navigation_bar/bottom_button_bar.dart';
 import 'package:circular_menu/circular_menu.dart';
 import 'package:flutter/material.dart';
 
@@ -13,19 +14,22 @@ class WorksHelpScreen extends StatelessWidget {
     return Scaffold(
       backgroundColor: const Color.fromRGBO(255, 214, 153, 1),
       body: SafeArea(
-          child: Column(children: <Widget>[
-        const Align(
-          alignment: Alignment.topLeft,
-          child: BackButton(),
-        ),
-        Center(
-          child: Column(children: <Widget>[
-            const Text('Musical Works Help', style: TextStyle(fontSize: 40)),
-            Padding(
-                padding: const EdgeInsets.all(40),
-                child: RichText(
-                    textAlign: TextAlign.justify,
-                    text: TextSpan(
+        child: Column(
+          children: <Widget>[
+            const Align(
+              alignment: Alignment.topLeft,
+              child: BackButton(),
+            ),
+            Center(
+              child: Column(
+                children: <Widget>[
+                  const Text('Musical Works Help',
+                      style: TextStyle(fontSize: 40)),
+                  Padding(
+                    padding: const EdgeInsets.all(40),
+                    child: RichText(
+                      textAlign: TextAlign.justify,
+                      text: TextSpan(
                         text: 'The Musical Works page, which you can access '
                             'with the ',
                         style:
@@ -63,30 +67,19 @@ class WorksHelpScreen extends StatelessWidget {
                               text: 'words that you don\'t recognize, click on '
                                   'them and you will be brought to a page '
                                   'explaining what they mean!'),
-                        ])))
-          ]),
-        )
-      ])),
-      floatingActionButtonLocation: FloatingActionButtonLocation.centerDocked,
-      floatingActionButton: CircularDialMenu.build(context),
-      bottomNavigationBar: BottomAppBar(
-        child: Row(
-          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-          children: [
-            IconButton(
-              onPressed: () => Navigator.pushNamedAndRemoveUntil(
-                  context, '/main', (route) => false),
-              tooltip: 'Home',
-              icon: const Icon(Icons.home, color: Colors.black45),
-            ),
-            IconButton(
-              onPressed: () {},
-              tooltip: 'Settings',
-              icon: const Icon(Icons.settings, color: Colors.black45),
+                        ],
+                      ),
+                    ),
+                  ),
+                ],
+              ),
             ),
           ],
         ),
       ),
+      floatingActionButtonLocation: FloatingActionButtonLocation.centerDocked,
+      floatingActionButton: CircularDialMenu.build(context),
+      bottomNavigationBar: BottomButtonBar.build(context),
     );
   }
 }

--- a/lib/settings/settings_menu.dart
+++ b/lib/settings/settings_menu.dart
@@ -1,4 +1,5 @@
 import 'package:artifact/Listen/Listen.dart';
+import 'package:artifact/bottom_navigation_bar/bottom_button_bar.dart';
 import 'package:flutter/material.dart';
 import 'package:artifact/bottom_navigation_bar/circular_dial_menu.dart';
 import 'package:artifact/music_box.dart';
@@ -15,8 +16,9 @@ class _SettingsScreenState extends State<SettingsScreen> {
   @override
   Widget build(BuildContext context) {
     openingState c = openingState();
-    final ButtonStyle style =
-        ElevatedButton.styleFrom(textStyle: const TextStyle(fontSize: 20));
+    final ButtonStyle style = ElevatedButton.styleFrom(
+      textStyle: const TextStyle(fontSize: 20),
+    );
     return Scaffold(
       backgroundColor: const Color.fromRGBO(255, 214, 153, 1),
       appBar: AppBar(
@@ -39,9 +41,11 @@ class _SettingsScreenState extends State<SettingsScreen> {
             IconButton(
               onPressed: () => {
                 if (mute) {c.unmute()} else {c.mute()},
-                setState(() {
-                  mute = !mute;
-                })
+                setState(
+                  () {
+                    mute = !mute;
+                  },
+                ),
               },
               tooltip: '',
               icon: mute
@@ -53,24 +57,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
       ),
       floatingActionButtonLocation: FloatingActionButtonLocation.centerDocked,
       floatingActionButton: CircularDialMenu.build(context),
-      bottomNavigationBar: BottomAppBar(
-        child: Row(
-          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-          children: [
-            IconButton(
-              onPressed: () => Navigator.pushNamedAndRemoveUntil(
-                  context, '/main', (route) => false),
-              tooltip: 'Home',
-              icon: const Icon(Icons.home, color: Colors.black45),
-            ),
-            IconButton(
-              onPressed: () {},
-              tooltip: 'Settings',
-              icon: const Icon(Icons.settings, color: Colors.black45),
-            ),
-          ],
-        ),
-      ),
+      bottomNavigationBar: BottomButtonBar.build(context),
     );
   }
 }

--- a/lib/settings/settings_menu.dart
+++ b/lib/settings/settings_menu.dart
@@ -1,8 +1,7 @@
 import 'package:artifact/Listen/Listen.dart';
 import 'package:flutter/material.dart';
-import 'package:artifact/circular_dial_menu.dart';
+import 'package:artifact/bottom_navigation_bar/circular_dial_menu.dart';
 import 'package:artifact/music_box.dart';
-
 
 class SettingsScreen extends StatefulWidget {
   const SettingsScreen({super.key});

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,126 +5,144 @@ packages:
     dependency: "direct main"
     description:
       name: animate_do
-      url: "https://pub.dartlang.org"
+      sha256: "9aeacc1a7238f971c039bdf45d13c628be554a242e0251c4ddda09d19a1a923f"
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.2"
   archive:
     dependency: transitive
     description:
       name: archive
-      url: "https://pub.dartlang.org"
+      sha256: d6347d54a2d8028e0437e3c099f66fdb8ae02c4720c1e7534c9f24c10351f85d
+      url: "https://pub.dev"
     source: hosted
     version: "3.3.6"
   args:
     dependency: transitive
     description:
       name: args
-      url: "https://pub.dartlang.org"
+      sha256: "4cab82a83ffef80b262ddedf47a0a8e56ee6fbf7fe21e6e768b02792034dd440"
+      url: "https://pub.dev"
     source: hosted
     version: "2.4.0"
   async:
     dependency: transitive
     description:
       name: async
-      url: "https://pub.dartlang.org"
+      sha256: bfe67ef28df125b7dddcea62755991f807aa39a2492a23e1550161692950bbe0
+      url: "https://pub.dev"
     source: hosted
-    version: "2.9.0"
+    version: "2.10.0"
   audio_session:
     dependency: transitive
     description:
       name: audio_session
-      url: "https://pub.dartlang.org"
+      sha256: e4acc4e9eaa32436dfc5d7aed7f0a370f2d7bb27ee27de30d6c4f220c2a05c73
+      url: "https://pub.dev"
     source: hosted
     version: "0.1.13"
   audio_video_progress_bar:
     dependency: "direct main"
     description:
       name: audio_video_progress_bar
-      url: "https://pub.dartlang.org"
+      sha256: "67f3a5ea70d48b48caaf29f5a0606284a6aa3a393736daf9e82bec985d2f9b70"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.1"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      url: "https://pub.dartlang.org"
+      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   characters:
     dependency: transitive
     description:
       name: characters
-      url: "https://pub.dartlang.org"
+      sha256: e6a326c8af69605aec75ed6c187d06b349707a27fbff8222ca9cc2cff167975c
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
   circular_menu:
     dependency: "direct main"
     description:
       name: circular_menu
-      url: "https://pub.dartlang.org"
+      sha256: "253e5e7aaf107e84251b0c51fb66ae17f6caaebf973eb30049f02b999646373a"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
   clock:
     dependency: transitive
     description:
       name: clock
-      url: "https://pub.dartlang.org"
+      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
   collection:
     dependency: transitive
     description:
       name: collection
-      url: "https://pub.dartlang.org"
+      sha256: cfc915e6923fe5ce6e153b0723c753045de46de1b4d63771530504004a45fae0
+      url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   convert:
     dependency: transitive
     description:
       name: convert
-      url: "https://pub.dartlang.org"
+      sha256: "0f08b14755d163f6e2134cb58222dd25ea2a2ee8a195e53983d57c075324d592"
+      url: "https://pub.dev"
     source: hosted
     version: "3.1.1"
   crypto:
     dependency: transitive
     description:
       name: crypto
-      url: "https://pub.dartlang.org"
+      sha256: aa274aa7774f8964e4f4f38cc994db7b6158dd36e9187aaceaddc994b35c6c67
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.2"
   csslib:
     dependency: transitive
     description:
       name: csslib
-      url: "https://pub.dartlang.org"
+      sha256: b36c7f7e24c0bdf1bf9a3da461c837d1de64b9f8beb190c9011d8c72a3dfd745
+      url: "https://pub.dev"
     source: hosted
     version: "0.17.2"
   cupertino_icons:
     dependency: "direct main"
     description:
       name: cupertino_icons
-      url: "https://pub.dartlang.org"
+      sha256: e35129dc44c9118cee2a5603506d823bab99c68393879edb440e0090d07586be
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.5"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
-      url: "https://pub.dartlang.org"
+      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
   ffi:
     dependency: transitive
     description:
       name: ffi
-      url: "https://pub.dartlang.org"
+      sha256: a38574032c5f1dd06c4aee541789906c12ccaab8ba01446e800d9c5b79c4a978
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
   file:
     dependency: transitive
     description:
       name: file
-      url: "https://pub.dartlang.org"
+      sha256: "1b92bec4fc2a72f59a8e15af5f52cd441e4a7860b49499d69dfa817af20e925d"
+      url: "https://pub.dev"
     source: hosted
     version: "6.1.4"
   flutter:
@@ -136,7 +154,8 @@ packages:
     dependency: "direct dev"
     description:
       name: flutter_native_splash
-      url: "https://pub.dartlang.org"
+      sha256: e301ae206ff0fb09b67d3716009c6c28c2da57a0ad164827b178421bb9d601f7
+      url: "https://pub.dev"
     source: hosted
     version: "2.2.18"
   flutter_test:
@@ -153,182 +172,208 @@ packages:
     dependency: "direct main"
     description:
       name: hive
-      url: "https://pub.dartlang.org"
+      sha256: "8dcf6db979d7933da8217edcec84e9df1bdb4e4edc7fc77dbd5aa74356d6d941"
+      url: "https://pub.dev"
     source: hosted
     version: "2.2.3"
   hive_flutter:
     dependency: "direct main"
     description:
       name: hive_flutter
-      url: "https://pub.dartlang.org"
+      sha256: dca1da446b1d808a51689fb5d0c6c9510c0a2ba01e22805d492c73b68e33eecc
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
   html:
     dependency: transitive
     description:
       name: html
-      url: "https://pub.dartlang.org"
+      sha256: "79d498e6d6761925a34ee5ea8fa6dfef38607781d2fa91e37523474282af55cb"
+      url: "https://pub.dev"
     source: hosted
     version: "0.15.2"
   image:
     dependency: transitive
     description:
       name: image
-      url: "https://pub.dartlang.org"
+      sha256: "483a389d6ccb292b570c31b3a193779b1b0178e7eb571986d9a49904b6861227"
+      url: "https://pub.dev"
     source: hosted
     version: "4.0.15"
   js:
     dependency: transitive
     description:
       name: js
-      url: "https://pub.dartlang.org"
+      sha256: "5528c2f391ededb7775ec1daa69e65a2d61276f7552de2b5f7b8d34ee9fd4ab7"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.6.4"
+    version: "0.6.5"
   just_audio:
     dependency: "direct main"
     description:
       name: just_audio
-      url: "https://pub.dartlang.org"
+      sha256: "7e6d31508dacd01a066e3889caf6282e5f1eb60707c230203b21a83af5c55586"
+      url: "https://pub.dev"
     source: hosted
     version: "0.9.32"
   just_audio_platform_interface:
     dependency: transitive
     description:
       name: just_audio_platform_interface
-      url: "https://pub.dartlang.org"
+      sha256: eff112d5138bea3ba544b6338b1e0537a32b5e1425e4d0dc38f732771cda7c84
+      url: "https://pub.dev"
     source: hosted
     version: "4.2.0"
   just_audio_web:
     dependency: transitive
     description:
       name: just_audio_web
-      url: "https://pub.dartlang.org"
+      sha256: "89d8db6f19f3821bb6bf908c4bfb846079afb2ab575b783d781a6bf119e3abaf"
+      url: "https://pub.dev"
     source: hosted
     version: "0.4.7"
   just_audio_windows:
     dependency: "direct main"
     description:
       name: just_audio_windows
-      url: "https://pub.dartlang.org"
+      sha256: "7b8801f3987e98a2002cd23b5600b2daf162248ff1413266fb44c84448c1c0d3"
+      url: "https://pub.dev"
     source: hosted
     version: "0.2.0"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      url: "https://pub.dartlang.org"
+      sha256: "16db949ceee371e9b99d22f88fa3a73c4e59fd0afed0bd25fc336eb76c198b72"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.12.12"
+    version: "0.12.13"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      url: "https://pub.dartlang.org"
+      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
+      url: "https://pub.dev"
     source: hosted
-    version: "0.1.5"
+    version: "0.2.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      url: "https://pub.dartlang.org"
+      sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"
+      url: "https://pub.dev"
     source: hosted
     version: "1.8.0"
   path:
     dependency: transitive
     description:
       name: path
-      url: "https://pub.dartlang.org"
+      sha256: db9d4f58c908a4ba5953fcee2ae317c94889433e5024c27ce74a37f94267945b
+      url: "https://pub.dev"
     source: hosted
     version: "1.8.2"
   path_provider:
     dependency: transitive
     description:
       name: path_provider
-      url: "https://pub.dartlang.org"
+      sha256: c7edf82217d4b2952b2129a61d3ad60f1075b9299e629e149a8d2e39c2e6aad4
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.14"
   path_provider_android:
     dependency: transitive
     description:
       name: path_provider_android
-      url: "https://pub.dartlang.org"
+      sha256: "019f18c9c10ae370b08dce1f3e3b73bc9f58e7f087bb5e921f06529438ac0ae7"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.24"
   path_provider_foundation:
     dependency: transitive
     description:
       name: path_provider_foundation
-      url: "https://pub.dartlang.org"
+      sha256: "818b2dc38b0f178e0ea3f7cf3b28146faab11375985d815942a68eee11c2d0f7"
+      url: "https://pub.dev"
     source: hosted
     version: "2.2.1"
   path_provider_linux:
     dependency: transitive
     description:
       name: path_provider_linux
-      url: "https://pub.dartlang.org"
+      sha256: "2ae08f2216225427e64ad224a24354221c2c7907e448e6e0e8b57b1eb9f10ad1"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.10"
   path_provider_platform_interface:
     dependency: transitive
     description:
       name: path_provider_platform_interface
-      url: "https://pub.dartlang.org"
+      sha256: "57585299a729335f1298b43245842678cb9f43a6310351b18fb577d6e33165ec"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.6"
   path_provider_windows:
     dependency: transitive
     description:
       name: path_provider_windows
-      url: "https://pub.dartlang.org"
+      sha256: f53720498d5a543f9607db4b0e997c4b5438884de25b0f73098cc2671a51b130
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.5"
   petitparser:
     dependency: transitive
     description:
       name: petitparser
-      url: "https://pub.dartlang.org"
+      sha256: "49392a45ced973e8d94a85fdb21293fbb40ba805fc49f2965101ae748a3683b4"
+      url: "https://pub.dev"
     source: hosted
     version: "5.1.0"
   platform:
     dependency: transitive
     description:
       name: platform
-      url: "https://pub.dartlang.org"
+      sha256: "4a451831508d7d6ca779f7ac6e212b4023dd5a7d08a27a63da33756410e32b76"
+      url: "https://pub.dev"
     source: hosted
     version: "3.1.0"
   plugin_platform_interface:
     dependency: transitive
     description:
       name: plugin_platform_interface
-      url: "https://pub.dartlang.org"
+      sha256: "6a2128648c854906c53fa8e33986fc0247a1116122f9534dd20e3ab9e16a32bc"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
   pointycastle:
     dependency: transitive
     description:
       name: pointycastle
-      url: "https://pub.dartlang.org"
+      sha256: c3120a968135aead39699267f4c74bc9a08e4e909e86bc1b0af5bfd78691123c
+      url: "https://pub.dev"
     source: hosted
     version: "3.7.2"
   process:
     dependency: transitive
     description:
       name: process
-      url: "https://pub.dartlang.org"
+      sha256: "53fd8db9cec1d37b0574e12f07520d582019cb6c44abf5479a01505099a34a09"
+      url: "https://pub.dev"
     source: hosted
     version: "4.2.4"
   rxdart:
     dependency: "direct main"
     description:
       name: rxdart
-      url: "https://pub.dartlang.org"
+      sha256: "0c7c0cedd93788d996e33041ffecda924cc54389199cde4e6a34b440f50044cb"
+      url: "https://pub.dev"
     source: hosted
     version: "0.27.7"
   seekbar:
     dependency: "direct main"
     description:
       name: seekbar
-      url: "https://pub.dartlang.org"
+      sha256: "97bd822b10cdea725b0562d51e67f77bc3525051a2d277a85fded48589ae86bc"
+      url: "https://pub.dev"
     source: hosted
     version: "0.0.2"
   sky_engine:
@@ -340,133 +385,152 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      url: "https://pub.dartlang.org"
+      sha256: dd904f795d4b4f3b870833847c461801f6750a9fa8e61ea5ac53f9422b31f250
+      url: "https://pub.dev"
     source: hosted
-    version: "1.9.0"
+    version: "1.9.1"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      url: "https://pub.dartlang.org"
+      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
+      url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.11.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      url: "https://pub.dartlang.org"
+      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      url: "https://pub.dartlang.org"
+      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.2.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      url: "https://pub.dartlang.org"
+      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      url: "https://pub.dartlang.org"
+      sha256: ad540f65f92caa91bf21dfc8ffb8c589d6e4dc0c2267818b4cc2792857706206
+      url: "https://pub.dev"
     source: hosted
-    version: "0.4.12"
+    version: "0.4.16"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
-      url: "https://pub.dartlang.org"
+      sha256: "26f87ade979c47a150c9eaab93ccd2bebe70a27dc0b4b29517f2904f04eb11a5"
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
   universal_io:
     dependency: transitive
     description:
       name: universal_io
-      url: "https://pub.dartlang.org"
+      sha256: "06866290206d196064fd61df4c7aea1ffe9a4e7c4ccaa8fcded42dd41948005d"
+      url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
   uuid:
     dependency: transitive
     description:
       name: uuid
-      url: "https://pub.dartlang.org"
+      sha256: "648e103079f7c64a36dc7d39369cabb358d377078a051d6ae2ad3aa539519313"
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.7"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      url: "https://pub.dartlang.org"
+      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.4"
   video_player:
     dependency: "direct main"
     description:
       name: video_player
-      url: "https://pub.dartlang.org"
+      sha256: de95f0e9405f29b5582573d4166132e71f83b3158aac14e8ee5767a54f4f1fbd
+      url: "https://pub.dev"
     source: hosted
     version: "2.6.1"
   video_player_android:
     dependency: transitive
     description:
       name: video_player_android
-      url: "https://pub.dartlang.org"
+      sha256: a592048a711d5739d9cea2255d425779f138d41095b9149bda60ce4bc1af8871
+      url: "https://pub.dev"
     source: hosted
     version: "2.4.4"
   video_player_avfoundation:
     dependency: transitive
     description:
       name: video_player_avfoundation
-      url: "https://pub.dartlang.org"
+      sha256: af308d08c672d5ff718c60127665249617c37a709cb8f0a18dd28a0360299b7c
+      url: "https://pub.dev"
     source: hosted
     version: "2.4.3"
   video_player_platform_interface:
     dependency: transitive
     description:
       name: video_player_platform_interface
-      url: "https://pub.dartlang.org"
+      sha256: a8c4dcae2a7a6e7cc1d7f9808294d968eca1993af34a98e95b9bdfa959bec684
+      url: "https://pub.dev"
     source: hosted
     version: "6.1.0"
   video_player_web:
     dependency: transitive
     description:
       name: video_player_web
-      url: "https://pub.dartlang.org"
+      sha256: "44ce41424d104dfb7cf6982cc6b84af2b007a24d126406025bf40de5d481c74c"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.16"
   win32:
     dependency: transitive
     description:
       name: win32
-      url: "https://pub.dartlang.org"
+      sha256: c9ebe7ee4ab0c2194e65d3a07d8c54c5d00bb001b76081c4a04cdb8448b59e46
+      url: "https://pub.dev"
     source: hosted
     version: "3.1.3"
   xdg_directories:
     dependency: transitive
     description:
       name: xdg_directories
-      url: "https://pub.dartlang.org"
+      sha256: ee1505df1426458f7f60aac270645098d318a8b4766d85fde75f76f2e21807d1
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
   xml:
     dependency: transitive
     description:
       name: xml
-      url: "https://pub.dartlang.org"
+      sha256: ac0e3f4bf00ba2708c33fbabbbe766300e509f8c82dbd4ab6525039813f7e2fb
+      url: "https://pub.dev"
     source: hosted
     version: "6.1.0"
   yaml:
     dependency: transitive
     description:
       name: yaml
-      url: "https://pub.dartlang.org"
+      sha256: "23812a9b125b48d4007117254bca50abb6c712352927eece9e155207b1db2370"
+      url: "https://pub.dev"
     source: hosted
     version: "3.1.1"
 sdks:


### PR DESCRIPTION
<!-- Feel free to use it and tweak some parts -->

#### Description
<!-- A general summary of your changes -->
- Added a new file that builds the shortcut buttons (Home and Settings) on the bottom bar
- Added trailing commas to files that had the ```BottomAppBar``` for consistent formatting
- Updated dependencies

#### Types of Changes
<!-- Feel free to remove the ones you don't use, or remove all of them and explain what type of change it is -->
- Non-Functional Change (non-user facing changes)

#### Notes
<!-- Extra things you want to include -->
- Technically there was a functional change. When the user clicks on the ```Home``` button, they cannot go back to the previous screens. This change was intentional, but I can revert it back to what it was before if we prefer to have the user be able to go back.
- Also the user can now press the ```Settings```  button within the ```Settings``` screen.

#### Checklist
<!-- Some reminders -->
- [ ] Moved the task in [Jira](https://jib-2329.atlassian.net/jira/software/projects/OM2329/boards/1) to 'In Review'
- [ ] Updated the Incremental Release Notes
- [ ] Moved the task in [Jira](https://jib-2329.atlassian.net/jira/software/projects/OM2329/boards/1) to 'Done' once merged
