### PR TITLE
Add ability to purchase rewards with earned points

### DIFF
--- a/lib/Quizzes/Quizzes.dart
+++ b/lib/Quizzes/Quizzes.dart
@@ -34,7 +34,7 @@ class QuizzesScreen extends StatelessWidget {
                           padding: const EdgeInsets.all(8),
                           child: TextButton(
                             onPressed: () {
-                              Navigator.pushNamed(context, '/rewardScreen');
+                              Navigator.pushNamed(context, '/rewardGallery');
                             },
                             child: Text(
                               'See Rewards\nPoints: ' +

--- a/lib/Quizzes/Results.dart
+++ b/lib/Quizzes/Results.dart
@@ -5,6 +5,8 @@ import 'package:flutter/material.dart';
 import 'package:artifact/bottom_navigation_bar/circular_dial_menu.dart';
 import 'package:hive/hive.dart';
 
+import '../hive_local_data/quiz_result/quiz_result_db.dart';
+
 class ResultsScreen extends StatelessWidget {
   final List<String> answers;
   final Quiz quiz;
@@ -74,6 +76,7 @@ class ResultsScreen extends StatelessWidget {
 
   Text getScore(int score) {
     Box box = Hive.box('userBox');
+    QuizResultDatabase _resultsDatabase = QuizResultDatabase();
     List results = _resultsDatabase.getQuizResultList(quiz.name);
     int i;
     int max = results[0][1];
@@ -92,13 +95,6 @@ class ResultsScreen extends StatelessWidget {
     box.put(quiz.name, results);
 
     if (max < score) {
-      if (box.get("REWARDPOINTS") == null) {
-        box.put("REWARDPOINTS", score - max);
-      } else {
-        int rpoints = box.get("REWARDPOINTS");
-        rpoints += score - max;
-        box.put("REWARDPOINTS", rpoints);
-      }
       if (score - max == 1) {
         return Text(
           "Score: " +

--- a/lib/hive_local_data/rewards/rewards_points_db.dart
+++ b/lib/hive_local_data/rewards/rewards_points_db.dart
@@ -1,18 +1,23 @@
 import 'package:hive_flutter/hive_flutter.dart';
 
+import '../../rewards/rewards_database.dart';
+
 /// Datebase that holds the user's rewards points.
 class RewardPointsDatabase {
   /// Key for the RewardsDatabase
   String _rewardPointsDataKey = "REWARDPOINTS";
+  String _rewardsDataKey = "REWARDSUNLOCKED";
 
   /// The amount of rewards points the user has.
   int rewardPoints = 0;
+  List<int> rewards = List<int>.filled(RewardsDatabase.getImages().length, 0);
 
   final _userBox = Hive.box('userBox');
 
   /// Run this method if 1st time running the app.
   void createInitialData() {
     _userBox.put(_rewardPointsDataKey, rewardPoints);
+    _userBox.put(_rewardsDataKey, rewards);
   }
 
   /// Load data from rewards database.
@@ -29,5 +34,11 @@ class RewardPointsDatabase {
   int getRewardPoints() {
     if (_userBox.get(_rewardPointsDataKey) == null) createInitialData();
     return _userBox.get(_rewardPointsDataKey);
+  }
+  
+  List<int> getRewardsUnlocked() {
+    if (_userBox.get(_rewardsDataKey) == null) createInitialData();
+    return _userBox.get(_rewardsDataKey);
+
   }
 }

--- a/lib/hive_local_data/rewards/rewards_points_db.dart
+++ b/lib/hive_local_data/rewards/rewards_points_db.dart
@@ -41,4 +41,20 @@ class RewardPointsDatabase {
     return _userBox.get(_rewardsDataKey);
 
   }
+
+  void unlock(int i) {
+    List<int> curr = _userBox.get(_rewardsDataKey);
+    curr[i] = 1;
+    print(curr);
+    _userBox.put(_rewardsDataKey, curr);
+  }
+
+  bool spend(int cost) {
+    int points = _userBox.get(_rewardPointsDataKey);
+    if (points < cost) {
+      return false;
+    }
+    _userBox.put(_rewardPointsDataKey, points - cost);
+    return true;
+  }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -97,7 +97,7 @@ class MyApp extends StatelessWidget {
         '/beethoven': (context) => const BeethovenScreen(),
         '/mozart': (context) => const MozartScreen(),
         '/bach': (context) => const BachScreen(),
-        '/rewardScreen': (context) => const PurchaseScreen(),
+        '/rewardScreen': (context) => PurchaseScreen(),
         '/rewardGallery': (context) => const GalleryScreen(),
       },
     );

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,6 +2,7 @@ import 'package:artifact/Quizzes/Results.dart';
 import 'package:artifact/bottom_navigation_bar/bottom_button_bar.dart';
 import 'package:artifact/hive_local_data/quiz_result/quiz_result_db.dart';
 import 'package:artifact/hive_local_data/rewards/rewards_points_db.dart';
+import 'package:artifact/rewards/rewards_gallery.dart';
 import 'package:artifact/rewards/rewards_screen.dart';
 import 'package:artifact/settings/about_screen.dart';
 import 'package:artifact/settings/help_menu.dart';
@@ -97,6 +98,7 @@ class MyApp extends StatelessWidget {
         '/mozart': (context) => const MozartScreen(),
         '/bach': (context) => const BachScreen(),
         '/rewardScreen': (context) => const PurchaseScreen(),
+        '/rewardGallery': (context) => const GalleryScreen(),
       },
     );
   }

--- a/lib/rewards/rewards_database.dart
+++ b/lib/rewards/rewards_database.dart
@@ -1,0 +1,10 @@
+class RewardsDatabase {
+  static List<String> images = [
+    'assets/images/1.png',
+    'assets/images/2.png',
+    'assets/images/3.png',
+  ];
+  static getImages() {
+    return images;
+  }
+}

--- a/lib/rewards/rewards_database.dart
+++ b/lib/rewards/rewards_database.dart
@@ -9,6 +9,7 @@ class RewardsDatabase {
     1,
     1,
   ];
+  static List<String> titles = ['Reward 1', 'Reward 2', 'Reward 3'];
 
   static getImages() {
     return images;

--- a/lib/rewards/rewards_database.dart
+++ b/lib/rewards/rewards_database.dart
@@ -4,7 +4,17 @@ class RewardsDatabase {
     'assets/images/2.png',
     'assets/images/3.png',
   ];
+  static List<int> costs = [
+    0,
+    1,
+    1,
+  ];
+
   static getImages() {
     return images;
+  }
+
+  static getCosts() {
+    return costs;
   }
 }

--- a/lib/rewards/rewards_gallery.dart
+++ b/lib/rewards/rewards_gallery.dart
@@ -1,0 +1,50 @@
+import 'package:artifact/bottom_navigation_bar/bottom_button_bar.dart';
+import 'package:artifact/rewards/rewards_database.dart';
+import 'package:flutter/material.dart';
+import 'package:artifact/main.dart';
+import 'package:artifact/bottom_navigation_bar/circular_dial_menu.dart';
+
+import '../hive_local_data/rewards/rewards_points_db.dart';
+
+class GalleryScreen extends StatefulWidget {
+  const GalleryScreen({super.key});
+
+  @override
+  State<GalleryScreen> createState() => _GalleryState();
+}
+
+class _GalleryState extends State<GalleryScreen> {
+  final List<String> images = RewardsDatabase.getImages();
+  int _curr = 0;
+  int points = rewardPointsData.getRewardPoints();
+
+  @override
+  Widget build(BuildContext context) {
+    List<int> unlocked = RewardPointsDatabase().getRewardsUnlocked();
+    SingleChildScrollView rewardsView = SingleChildScrollView();
+    return Scaffold(
+      backgroundColor: const Color.fromRGBO(225, 255, 195, 1),
+      body: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: <Widget>[
+          const SizedBox(height: 28),
+          const Align(
+            alignment: Alignment.topLeft,
+            child: BackButton(),
+          ),
+          const Text(
+            'Rewards',
+            style: TextStyle(
+              fontSize: 25,
+              color: Colors.black,
+            ),
+          ),
+          rewardsView,
+        ],
+      ),
+      floatingActionButtonLocation: FloatingActionButtonLocation.centerDocked,
+      floatingActionButton: CircularDialMenu.build(context),
+      bottomNavigationBar: BottomButtonBar.build(context),
+    );
+  }
+}

--- a/lib/rewards/rewards_gallery.dart
+++ b/lib/rewards/rewards_gallery.dart
@@ -1,5 +1,6 @@
 import 'package:artifact/bottom_navigation_bar/bottom_button_bar.dart';
 import 'package:artifact/rewards/rewards_database.dart';
+import 'package:artifact/rewards/rewards_screen.dart';
 import 'package:flutter/material.dart';
 import 'package:artifact/main.dart';
 import 'package:artifact/bottom_navigation_bar/circular_dial_menu.dart';
@@ -15,13 +16,95 @@ class GalleryScreen extends StatefulWidget {
 
 class _GalleryState extends State<GalleryScreen> {
   final List<String> images = RewardsDatabase.getImages();
-  int _curr = 0;
   int points = rewardPointsData.getRewardPoints();
 
   @override
   Widget build(BuildContext context) {
     List<int> unlocked = RewardPointsDatabase().getRewardsUnlocked();
-    SingleChildScrollView rewardsView = SingleChildScrollView();
+    List<Widget> widgetList = [];
+    int i;
+    unlocked[1] = 1;
+    for (i = 0; i < unlocked.length; i++) {
+      if (unlocked[i] == 1) {
+        int index = i;
+        widgetList.add(SizedBox(
+            height: 100,
+            width: 100,
+            child: OutlinedButton(
+                style: OutlinedButton.styleFrom(
+                  backgroundColor: Color.fromRGBO(255, 255, 255, 1.0),
+                  foregroundColor: Color.fromRGBO(0, 0, 0, 1.0),
+                  side: BorderSide(
+                      width: 5.0, color: Color.fromRGBO(194, 232, 139, 1.0)),
+                  elevation: 5,
+                  //fixedSize: Size:,
+                ),
+                onPressed: () async {
+                  PurchaseScreen nextScreen = PurchaseScreen();
+                  nextScreen.setCurr(index);
+                  await Navigator.push(
+                    context,
+                    MaterialPageRoute(builder: (context) => nextScreen),
+                  );
+                  setState(() {});
+                },
+                child: Image.asset(images[i]))));
+      } else {
+        int index = i;
+        widgetList.add(SizedBox(
+            height: 100,
+            width: 100,
+            child: OutlinedButton(
+              style: OutlinedButton.styleFrom(
+                backgroundColor: Color.fromRGBO(255, 255, 255, 1.0),
+                foregroundColor: Color.fromRGBO(0, 0, 0, 1.0),
+                side: BorderSide(
+                    width: 5.0, color: Color.fromRGBO(194, 232, 139, 1.0)),
+                elevation: 5,
+                //fixedSize: Size:,
+              ),
+              onPressed: () async {
+                PurchaseScreen nextScreen = PurchaseScreen();
+                nextScreen.setCurr(index);
+                await Navigator.push(
+                  context,
+                  MaterialPageRoute(builder: (context) => nextScreen),
+                );
+                setState(() {});
+              },
+              child: Icon(Icons.question_mark, color: Colors.black),
+            )));
+      }
+    }
+    for (i--; i % 3 != 0; i++) {
+      widgetList.add(SizedBox(
+        height: 100,
+        width: 100,
+      ));
+    }
+    i = 5;
+
+    List<Widget> rewardList = [];
+    for (i = 0; i < unlocked.length; i += 3) {
+      rewardList.add(
+          Row(mainAxisAlignment: MainAxisAlignment.center, children: <Widget>[
+        widgetList[i],
+        SizedBox(width: 10),
+        widgetList[i + 1],
+        SizedBox(width: 10),
+        widgetList[i + 2],
+      ]));
+      rewardList.add(SizedBox(height: 10));
+    }
+    SizedBox rewardsView = SizedBox(
+        height: 200,
+        child: ListView.builder(
+            //shrinkWrap: true,
+            //padding: const EdgeInsets.all(20.0),
+            itemCount: rewardList.length,
+            itemBuilder: (context, position) {
+              return rewardList[position];
+            }));
     return Scaffold(
       backgroundColor: const Color.fromRGBO(225, 255, 195, 1),
       body: Column(
@@ -39,7 +122,16 @@ class _GalleryState extends State<GalleryScreen> {
               color: Colors.black,
             ),
           ),
-          rewardsView,
+          Text(
+            'Points Available: ' + points.toString(),
+            style: TextStyle(
+              fontSize: 25,
+              color: Colors.black,
+            ),
+          ),
+          Padding(
+              padding: EdgeInsets.symmetric(horizontal: 25),
+              child: rewardsView),
         ],
       ),
       floatingActionButtonLocation: FloatingActionButtonLocation.centerDocked,

--- a/lib/rewards/rewards_gallery.dart
+++ b/lib/rewards/rewards_gallery.dart
@@ -20,10 +20,9 @@ class _GalleryState extends State<GalleryScreen> {
 
   @override
   Widget build(BuildContext context) {
-    List<int> unlocked = RewardPointsDatabase().getRewardsUnlocked();
+    List<int> unlocked = rewardPointsData.getRewardsUnlocked();
     List<Widget> widgetList = [];
     int i;
-    unlocked[1] = 1;
     for (i = 0; i < unlocked.length; i++) {
       if (unlocked[i] == 1) {
         int index = i;
@@ -46,6 +45,7 @@ class _GalleryState extends State<GalleryScreen> {
                     context,
                     MaterialPageRoute(builder: (context) => nextScreen),
                   );
+                  points = rewardPointsData.getRewardPoints();
                   setState(() {});
                 },
                 child: Image.asset(images[i]))));
@@ -70,6 +70,7 @@ class _GalleryState extends State<GalleryScreen> {
                   context,
                   MaterialPageRoute(builder: (context) => nextScreen),
                 );
+                points = rewardPointsData.getRewardPoints();
                 setState(() {});
               },
               child: Icon(Icons.question_mark, color: Colors.black),
@@ -118,7 +119,7 @@ class _GalleryState extends State<GalleryScreen> {
           const Text(
             'Rewards',
             style: TextStyle(
-              fontSize: 25,
+              fontSize: 40,
               color: Colors.black,
             ),
           ),

--- a/lib/rewards/rewards_screen.dart
+++ b/lib/rewards/rewards_screen.dart
@@ -37,8 +37,7 @@ class _PurchaseScreenState extends State<PurchaseScreen> {
 
   @override
   Widget build(BuildContext context) {
-    RewardPointsDatabase RPD = RewardPointsDatabase();
-    List<int> unlocked = RPD.getRewardsUnlocked();
+    List<int> unlocked = rewardPointsData.getRewardsUnlocked();
     Widget disp;
     if (unlocked[widget._curr] == 0) {
       disp = Column(
@@ -54,30 +53,44 @@ class _PurchaseScreenState extends State<PurchaseScreen> {
           SizedBox(
             height: 30,
           ),
-          SizedBox(
+          const SizedBox(
             height: 250,
             width: 250,
-            child: Image.asset(images[widget._curr]),
+            child: DecoratedBox(
+              decoration: BoxDecoration(color: Colors.grey),
+              child: Icon(
+                Icons.question_mark,
+                color: Colors.black,
+                size: 100,
+              ),
+            ),
           ),
           SizedBox(
             height: 30,
           ),
-          OutlinedButton(
-            style: OutlinedButton.styleFrom(
-              backgroundColor: Color.fromRGBO(255, 255, 255, 1.0),
-              foregroundColor: Color.fromRGBO(0, 0, 0, 1.0),
-              side: BorderSide(
-                  width: 5.0, color: Color.fromRGBO(194, 232, 139, 1.0)),
-              elevation: 5,
-              //fixedSize: Size:,
+          SizedBox(
+            height: 50,
+            width: 100,
+            child: OutlinedButton(
+              style: OutlinedButton.styleFrom(
+                backgroundColor: Color.fromRGBO(255, 255, 255, 1.0),
+                foregroundColor: Color.fromRGBO(0, 0, 0, 1.0),
+                side: BorderSide(
+                    width: 5.0, color: Color.fromRGBO(194, 232, 139, 1.0)),
+                elevation: 5,
+                //fixedSize: Size:,
+              ),
+              onPressed: () {
+                if (rewardPointsData
+                    .spend(RewardsDatabase.getCosts()[widget._curr])) {
+                  rewardPointsData.unlock(widget._curr);
+                }
+                points = rewardPointsData.getRewardPoints();
+                setState(() {});
+              },
+              child: Text("Cost: " +
+                  RewardsDatabase.getCosts()[widget._curr].toString()),
             ),
-            onPressed: () {
-              if (RPD.spend(RewardsDatabase.getCosts()[widget._curr])) {
-                RPD.unlock(widget._curr);
-              }
-              setState(() {});
-            },
-            child: Text("Cost: " + RewardsDatabase.getCosts()[widget._curr].toString()),
           ),
           SizedBox(
             height: 30,
@@ -121,6 +134,20 @@ class _PurchaseScreenState extends State<PurchaseScreen> {
             height: 250,
             width: 250,
             child: Image.asset(images[widget._curr]),
+          ),
+          SizedBox(
+            height: 30,
+          ),
+          SizedBox(
+            height: 50,
+            child: Text(
+              RewardsDatabase.titles[widget._curr],
+              style: TextStyle(
+                fontSize: 25,
+                color: Colors.black,
+              ),
+              textScaleFactor: MediaQuery.of(context).textScaleFactor,
+            ),
           ),
           SizedBox(
             height: 30,

--- a/lib/rewards/rewards_screen.dart
+++ b/lib/rewards/rewards_screen.dart
@@ -4,31 +4,149 @@ import 'package:flutter/material.dart';
 import 'package:artifact/main.dart';
 import 'package:artifact/bottom_navigation_bar/circular_dial_menu.dart';
 
+import '../hive_local_data/rewards/rewards_points_db.dart';
+
 class PurchaseScreen extends StatefulWidget {
-  const PurchaseScreen({ super.key });
+  int _curr = 0;
+
+  PurchaseScreen({super.key});
 
   @override
   State<PurchaseScreen> createState() => _PurchaseScreenState();
+
+  void setCurr(int curr) {
+    _curr = curr;
+  }
 }
 
 class _PurchaseScreenState extends State<PurchaseScreen> {
   final List<String> images = RewardsDatabase.getImages();
-  int _curr = 0;
   int points = rewardPointsData.getRewardPoints();
 
   void _nextImage() {
     setState(() {
-      _curr = (_curr + 1) % images.length;
+      widget._curr = (widget._curr + 1) % images.length;
     });
   }
+
   void _previousImage() {
     setState(() {
-      _curr = (_curr - 1) % images.length;
+      widget._curr = (widget._curr - 1) % images.length;
     });
   }
 
   @override
   Widget build(BuildContext context) {
+    RewardPointsDatabase RPD = RewardPointsDatabase();
+    List<int> unlocked = RPD.getRewardsUnlocked();
+    Widget disp;
+    if (unlocked[widget._curr] == 0) {
+      disp = Column(
+        children: <Widget>[
+          Text(
+            "Current Points: " + points.toString(),
+            style: TextStyle(
+              fontSize: 25,
+              color: Colors.black,
+            ),
+            textScaleFactor: MediaQuery.of(context).textScaleFactor,
+          ),
+          SizedBox(
+            height: 30,
+          ),
+          SizedBox(
+            height: 250,
+            width: 250,
+            child: Image.asset(images[widget._curr]),
+          ),
+          SizedBox(
+            height: 30,
+          ),
+          OutlinedButton(
+            style: OutlinedButton.styleFrom(
+              backgroundColor: Color.fromRGBO(255, 255, 255, 1.0),
+              foregroundColor: Color.fromRGBO(0, 0, 0, 1.0),
+              side: BorderSide(
+                  width: 5.0, color: Color.fromRGBO(194, 232, 139, 1.0)),
+              elevation: 5,
+              //fixedSize: Size:,
+            ),
+            onPressed: () {
+              if (RPD.spend(RewardsDatabase.getCosts()[widget._curr])) {
+                RPD.unlock(widget._curr);
+              }
+              setState(() {});
+            },
+            child: Text("Cost: " + RewardsDatabase.getCosts()[widget._curr].toString()),
+          ),
+          SizedBox(
+            height: 30,
+          ),
+          Row(
+            children: <Widget>[
+              IconButton(
+                iconSize: 50,
+                onPressed: _previousImage,
+                icon: Icon(Icons.arrow_left, color: Colors.black45),
+              ),
+              SizedBox(
+                width: 30,
+              ),
+              IconButton(
+                iconSize: 50,
+                onPressed: _nextImage,
+                icon: Icon(Icons.arrow_right, color: Colors.black45),
+              ),
+            ],
+            mainAxisAlignment: MainAxisAlignment.center,
+            crossAxisAlignment: CrossAxisAlignment.center,
+          ),
+        ],
+      );
+    } else {
+      disp = Column(
+        children: <Widget>[
+          Text(
+            "Current Points: " + points.toString(),
+            style: TextStyle(
+              fontSize: 25,
+              color: Colors.black,
+            ),
+            textScaleFactor: MediaQuery.of(context).textScaleFactor,
+          ),
+          SizedBox(
+            height: 30,
+          ),
+          SizedBox(
+            height: 250,
+            width: 250,
+            child: Image.asset(images[widget._curr]),
+          ),
+          SizedBox(
+            height: 30,
+          ),
+          Row(
+            children: <Widget>[
+              IconButton(
+                iconSize: 50,
+                onPressed: _previousImage,
+                icon: Icon(Icons.arrow_left, color: Colors.black45),
+              ),
+              SizedBox(
+                width: 30,
+              ),
+              IconButton(
+                iconSize: 50,
+                onPressed: _nextImage,
+                icon: Icon(Icons.arrow_right, color: Colors.black45),
+              ),
+            ],
+            mainAxisAlignment: MainAxisAlignment.center,
+            crossAxisAlignment: CrossAxisAlignment.center,
+          ),
+        ],
+      );
+    }
     return Scaffold(
       backgroundColor: const Color.fromRGBO(225, 255, 195, 1),
       body: Column(
@@ -42,42 +160,11 @@ class _PurchaseScreenState extends State<PurchaseScreen> {
           Center(
             child: Padding(
               padding: const EdgeInsets.all(0),
-              child: Column(
-                children: <Widget>[
-                  Text("Current Points: " + points.toString(),
-                    style: TextStyle(
-                      fontSize: 25,
-                      color: Colors.black,
-                    ),
-                    textScaleFactor:
-                    MediaQuery.of(context).textScaleFactor,),
-                  SizedBox(height: 30,),
-                  Image.asset(images[_curr]),
-                  SizedBox(height: 30,),
-                  Row(
-                    children: <Widget>[
-                      IconButton(
-                        iconSize: 50,
-                        onPressed: _previousImage,
-                        icon: Icon(Icons.arrow_left, color: Colors.black45),
-                      ),
-                      SizedBox(width: 30,),
-                      IconButton(
-                        iconSize: 50,
-                        onPressed: _nextImage,
-                        icon: Icon(Icons.arrow_right, color: Colors.black45),
-                      ),
-                    ],
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    crossAxisAlignment: CrossAxisAlignment.center,
-                  ),
-                ],
-              ),
+              child: disp,
             ),
           ),
         ],
       ),
-
       floatingActionButtonLocation: FloatingActionButtonLocation.centerDocked,
       floatingActionButton: CircularDialMenu.build(context),
       bottomNavigationBar: BottomButtonBar.build(context),

--- a/lib/rewards/rewards_screen.dart
+++ b/lib/rewards/rewards_screen.dart
@@ -1,4 +1,5 @@
 import 'package:artifact/bottom_navigation_bar/bottom_button_bar.dart';
+import 'package:artifact/rewards/rewards_database.dart';
 import 'package:flutter/material.dart';
 import 'package:artifact/main.dart';
 import 'package:artifact/bottom_navigation_bar/circular_dial_menu.dart';
@@ -11,11 +12,7 @@ class PurchaseScreen extends StatefulWidget {
 }
 
 class _PurchaseScreenState extends State<PurchaseScreen> {
-  final List<String> images = [
-    'assets/images/1.png',
-    'assets/images/2.png',
-    'assets/images/3.png',
-  ];
+  final List<String> images = RewardsDatabase.getImages();
   int _curr = 0;
   int points = rewardPointsData.getRewardPoints();
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,126 +5,144 @@ packages:
     dependency: "direct main"
     description:
       name: animate_do
-      url: "https://pub.dartlang.org"
+      sha256: "9aeacc1a7238f971c039bdf45d13c628be554a242e0251c4ddda09d19a1a923f"
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.2"
   archive:
     dependency: transitive
     description:
       name: archive
-      url: "https://pub.dartlang.org"
+      sha256: "0c8368c9b3f0abbc193b9d6133649a614204b528982bebc7026372d61677ce3a"
+      url: "https://pub.dev"
     source: hosted
     version: "3.3.7"
   args:
     dependency: transitive
     description:
       name: args
-      url: "https://pub.dartlang.org"
+      sha256: "4cab82a83ffef80b262ddedf47a0a8e56ee6fbf7fe21e6e768b02792034dd440"
+      url: "https://pub.dev"
     source: hosted
     version: "2.4.0"
   async:
     dependency: transitive
     description:
       name: async
-      url: "https://pub.dartlang.org"
+      sha256: bfe67ef28df125b7dddcea62755991f807aa39a2492a23e1550161692950bbe0
+      url: "https://pub.dev"
     source: hosted
-    version: "2.9.0"
+    version: "2.10.0"
   audio_session:
     dependency: transitive
     description:
       name: audio_session
-      url: "https://pub.dartlang.org"
+      sha256: e4acc4e9eaa32436dfc5d7aed7f0a370f2d7bb27ee27de30d6c4f220c2a05c73
+      url: "https://pub.dev"
     source: hosted
     version: "0.1.13"
   audio_video_progress_bar:
     dependency: "direct main"
     description:
       name: audio_video_progress_bar
-      url: "https://pub.dartlang.org"
+      sha256: "67f3a5ea70d48b48caaf29f5a0606284a6aa3a393736daf9e82bec985d2f9b70"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.1"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      url: "https://pub.dartlang.org"
+      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   characters:
     dependency: transitive
     description:
       name: characters
-      url: "https://pub.dartlang.org"
+      sha256: e6a326c8af69605aec75ed6c187d06b349707a27fbff8222ca9cc2cff167975c
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
   circular_menu:
     dependency: "direct main"
     description:
       name: circular_menu
-      url: "https://pub.dartlang.org"
+      sha256: "253e5e7aaf107e84251b0c51fb66ae17f6caaebf973eb30049f02b999646373a"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
   clock:
     dependency: transitive
     description:
       name: clock
-      url: "https://pub.dartlang.org"
+      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
   collection:
     dependency: transitive
     description:
       name: collection
-      url: "https://pub.dartlang.org"
+      sha256: cfc915e6923fe5ce6e153b0723c753045de46de1b4d63771530504004a45fae0
+      url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   convert:
     dependency: transitive
     description:
       name: convert
-      url: "https://pub.dartlang.org"
+      sha256: "0f08b14755d163f6e2134cb58222dd25ea2a2ee8a195e53983d57c075324d592"
+      url: "https://pub.dev"
     source: hosted
     version: "3.1.1"
   crypto:
     dependency: transitive
     description:
       name: crypto
-      url: "https://pub.dartlang.org"
+      sha256: aa274aa7774f8964e4f4f38cc994db7b6158dd36e9187aaceaddc994b35c6c67
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.2"
   csslib:
     dependency: transitive
     description:
       name: csslib
-      url: "https://pub.dartlang.org"
+      sha256: b36c7f7e24c0bdf1bf9a3da461c837d1de64b9f8beb190c9011d8c72a3dfd745
+      url: "https://pub.dev"
     source: hosted
     version: "0.17.2"
   cupertino_icons:
     dependency: "direct main"
     description:
       name: cupertino_icons
-      url: "https://pub.dartlang.org"
+      sha256: e35129dc44c9118cee2a5603506d823bab99c68393879edb440e0090d07586be
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.5"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
-      url: "https://pub.dartlang.org"
+      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
   ffi:
     dependency: transitive
     description:
       name: ffi
-      url: "https://pub.dartlang.org"
+      sha256: a38574032c5f1dd06c4aee541789906c12ccaab8ba01446e800d9c5b79c4a978
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
   file:
     dependency: transitive
     description:
       name: file
-      url: "https://pub.dartlang.org"
+      sha256: "1b92bec4fc2a72f59a8e15af5f52cd441e4a7860b49499d69dfa817af20e925d"
+      url: "https://pub.dev"
     source: hosted
     version: "6.1.4"
   flutter:
@@ -136,7 +154,8 @@ packages:
     dependency: "direct dev"
     description:
       name: flutter_native_splash
-      url: "https://pub.dartlang.org"
+      sha256: e301ae206ff0fb09b67d3716009c6c28c2da57a0ad164827b178421bb9d601f7
+      url: "https://pub.dev"
     source: hosted
     version: "2.2.18"
   flutter_test:
@@ -153,182 +172,208 @@ packages:
     dependency: "direct main"
     description:
       name: hive
-      url: "https://pub.dartlang.org"
+      sha256: "8dcf6db979d7933da8217edcec84e9df1bdb4e4edc7fc77dbd5aa74356d6d941"
+      url: "https://pub.dev"
     source: hosted
     version: "2.2.3"
   hive_flutter:
     dependency: "direct main"
     description:
       name: hive_flutter
-      url: "https://pub.dartlang.org"
+      sha256: dca1da446b1d808a51689fb5d0c6c9510c0a2ba01e22805d492c73b68e33eecc
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
   html:
     dependency: transitive
     description:
       name: html
-      url: "https://pub.dartlang.org"
+      sha256: "79d498e6d6761925a34ee5ea8fa6dfef38607781d2fa91e37523474282af55cb"
+      url: "https://pub.dev"
     source: hosted
     version: "0.15.2"
   image:
     dependency: transitive
     description:
       name: image
-      url: "https://pub.dartlang.org"
+      sha256: "483a389d6ccb292b570c31b3a193779b1b0178e7eb571986d9a49904b6861227"
+      url: "https://pub.dev"
     source: hosted
     version: "4.0.15"
   js:
     dependency: transitive
     description:
       name: js
-      url: "https://pub.dartlang.org"
+      sha256: "5528c2f391ededb7775ec1daa69e65a2d61276f7552de2b5f7b8d34ee9fd4ab7"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.6.4"
+    version: "0.6.5"
   just_audio:
     dependency: "direct main"
     description:
       name: just_audio
-      url: "https://pub.dartlang.org"
+      sha256: "7e6d31508dacd01a066e3889caf6282e5f1eb60707c230203b21a83af5c55586"
+      url: "https://pub.dev"
     source: hosted
     version: "0.9.32"
   just_audio_platform_interface:
     dependency: transitive
     description:
       name: just_audio_platform_interface
-      url: "https://pub.dartlang.org"
+      sha256: eff112d5138bea3ba544b6338b1e0537a32b5e1425e4d0dc38f732771cda7c84
+      url: "https://pub.dev"
     source: hosted
     version: "4.2.0"
   just_audio_web:
     dependency: transitive
     description:
       name: just_audio_web
-      url: "https://pub.dartlang.org"
+      sha256: "89d8db6f19f3821bb6bf908c4bfb846079afb2ab575b783d781a6bf119e3abaf"
+      url: "https://pub.dev"
     source: hosted
     version: "0.4.7"
   just_audio_windows:
     dependency: "direct main"
     description:
       name: just_audio_windows
-      url: "https://pub.dartlang.org"
+      sha256: "7b8801f3987e98a2002cd23b5600b2daf162248ff1413266fb44c84448c1c0d3"
+      url: "https://pub.dev"
     source: hosted
     version: "0.2.0"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      url: "https://pub.dartlang.org"
+      sha256: "16db949ceee371e9b99d22f88fa3a73c4e59fd0afed0bd25fc336eb76c198b72"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.12.12"
+    version: "0.12.13"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      url: "https://pub.dartlang.org"
+      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
+      url: "https://pub.dev"
     source: hosted
-    version: "0.1.5"
+    version: "0.2.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      url: "https://pub.dartlang.org"
+      sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"
+      url: "https://pub.dev"
     source: hosted
     version: "1.8.0"
   path:
     dependency: transitive
     description:
       name: path
-      url: "https://pub.dartlang.org"
+      sha256: db9d4f58c908a4ba5953fcee2ae317c94889433e5024c27ce74a37f94267945b
+      url: "https://pub.dev"
     source: hosted
     version: "1.8.2"
   path_provider:
     dependency: transitive
     description:
       name: path_provider
-      url: "https://pub.dartlang.org"
+      sha256: c7edf82217d4b2952b2129a61d3ad60f1075b9299e629e149a8d2e39c2e6aad4
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.14"
   path_provider_android:
     dependency: transitive
     description:
       name: path_provider_android
-      url: "https://pub.dartlang.org"
+      sha256: da97262be945a72270513700a92b39dd2f4a54dad55d061687e2e37a6390366a
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.25"
   path_provider_foundation:
     dependency: transitive
     description:
       name: path_provider_foundation
-      url: "https://pub.dartlang.org"
+      sha256: ad4c4d011830462633f03eb34445a45345673dfd4faf1ab0b4735fbd93b19183
+      url: "https://pub.dev"
     source: hosted
     version: "2.2.2"
   path_provider_linux:
     dependency: transitive
     description:
       name: path_provider_linux
-      url: "https://pub.dartlang.org"
+      sha256: "2ae08f2216225427e64ad224a24354221c2c7907e448e6e0e8b57b1eb9f10ad1"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.10"
   path_provider_platform_interface:
     dependency: transitive
     description:
       name: path_provider_platform_interface
-      url: "https://pub.dartlang.org"
+      sha256: "57585299a729335f1298b43245842678cb9f43a6310351b18fb577d6e33165ec"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.6"
   path_provider_windows:
     dependency: transitive
     description:
       name: path_provider_windows
-      url: "https://pub.dartlang.org"
+      sha256: f53720498d5a543f9607db4b0e997c4b5438884de25b0f73098cc2671a51b130
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.5"
   petitparser:
     dependency: transitive
     description:
       name: petitparser
-      url: "https://pub.dartlang.org"
+      sha256: "49392a45ced973e8d94a85fdb21293fbb40ba805fc49f2965101ae748a3683b4"
+      url: "https://pub.dev"
     source: hosted
     version: "5.1.0"
   platform:
     dependency: transitive
     description:
       name: platform
-      url: "https://pub.dartlang.org"
+      sha256: "4a451831508d7d6ca779f7ac6e212b4023dd5a7d08a27a63da33756410e32b76"
+      url: "https://pub.dev"
     source: hosted
     version: "3.1.0"
   plugin_platform_interface:
     dependency: transitive
     description:
       name: plugin_platform_interface
-      url: "https://pub.dartlang.org"
+      sha256: "6a2128648c854906c53fa8e33986fc0247a1116122f9534dd20e3ab9e16a32bc"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
   pointycastle:
     dependency: transitive
     description:
       name: pointycastle
-      url: "https://pub.dartlang.org"
+      sha256: "7c1e5f0d23c9016c5bbd8b1473d0d3fb3fc851b876046039509e18e0c7485f2c"
+      url: "https://pub.dev"
     source: hosted
     version: "3.7.3"
   process:
     dependency: transitive
     description:
       name: process
-      url: "https://pub.dartlang.org"
+      sha256: "53fd8db9cec1d37b0574e12f07520d582019cb6c44abf5479a01505099a34a09"
+      url: "https://pub.dev"
     source: hosted
     version: "4.2.4"
   rxdart:
     dependency: "direct main"
     description:
       name: rxdart
-      url: "https://pub.dartlang.org"
+      sha256: "0c7c0cedd93788d996e33041ffecda924cc54389199cde4e6a34b440f50044cb"
+      url: "https://pub.dev"
     source: hosted
     version: "0.27.7"
   seekbar:
     dependency: "direct main"
     description:
       name: seekbar
-      url: "https://pub.dartlang.org"
+      sha256: "97bd822b10cdea725b0562d51e67f77bc3525051a2d277a85fded48589ae86bc"
+      url: "https://pub.dev"
     source: hosted
     version: "0.0.2"
   sky_engine:
@@ -340,133 +385,152 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      url: "https://pub.dartlang.org"
+      sha256: dd904f795d4b4f3b870833847c461801f6750a9fa8e61ea5ac53f9422b31f250
+      url: "https://pub.dev"
     source: hosted
-    version: "1.9.0"
+    version: "1.9.1"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      url: "https://pub.dartlang.org"
+      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
+      url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.11.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      url: "https://pub.dartlang.org"
+      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      url: "https://pub.dartlang.org"
+      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.2.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      url: "https://pub.dartlang.org"
+      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      url: "https://pub.dartlang.org"
+      sha256: ad540f65f92caa91bf21dfc8ffb8c589d6e4dc0c2267818b4cc2792857706206
+      url: "https://pub.dev"
     source: hosted
-    version: "0.4.12"
+    version: "0.4.16"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
-      url: "https://pub.dartlang.org"
+      sha256: "26f87ade979c47a150c9eaab93ccd2bebe70a27dc0b4b29517f2904f04eb11a5"
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
   universal_io:
     dependency: transitive
     description:
       name: universal_io
-      url: "https://pub.dartlang.org"
+      sha256: "06866290206d196064fd61df4c7aea1ffe9a4e7c4ccaa8fcded42dd41948005d"
+      url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
   uuid:
     dependency: transitive
     description:
       name: uuid
-      url: "https://pub.dartlang.org"
+      sha256: "648e103079f7c64a36dc7d39369cabb358d377078a051d6ae2ad3aa539519313"
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.7"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      url: "https://pub.dartlang.org"
+      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.4"
   video_player:
     dependency: "direct main"
     description:
       name: video_player
-      url: "https://pub.dartlang.org"
+      sha256: de95f0e9405f29b5582573d4166132e71f83b3158aac14e8ee5767a54f4f1fbd
+      url: "https://pub.dev"
     source: hosted
     version: "2.6.1"
   video_player_android:
     dependency: transitive
     description:
       name: video_player_android
-      url: "https://pub.dartlang.org"
+      sha256: a592048a711d5739d9cea2255d425779f138d41095b9149bda60ce4bc1af8871
+      url: "https://pub.dev"
     source: hosted
     version: "2.4.4"
   video_player_avfoundation:
     dependency: transitive
     description:
       name: video_player_avfoundation
-      url: "https://pub.dartlang.org"
+      sha256: "75c6d68cd479a25f34d635149ba6887bc8f1b2b2921841121fd44ea0c5bc1927"
+      url: "https://pub.dev"
     source: hosted
     version: "2.4.4"
   video_player_platform_interface:
     dependency: transitive
     description:
       name: video_player_platform_interface
-      url: "https://pub.dartlang.org"
+      sha256: a8c4dcae2a7a6e7cc1d7f9808294d968eca1993af34a98e95b9bdfa959bec684
+      url: "https://pub.dev"
     source: hosted
     version: "6.1.0"
   video_player_web:
     dependency: transitive
     description:
       name: video_player_web
-      url: "https://pub.dartlang.org"
+      sha256: "44ce41424d104dfb7cf6982cc6b84af2b007a24d126406025bf40de5d481c74c"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.16"
   win32:
     dependency: transitive
     description:
       name: win32
-      url: "https://pub.dartlang.org"
+      sha256: a6f0236dbda0f63aa9a25ad1ff9a9d8a4eaaa5012da0dc59d21afdb1dc361ca4
+      url: "https://pub.dev"
     source: hosted
     version: "3.1.4"
   xdg_directories:
     dependency: transitive
     description:
       name: xdg_directories
-      url: "https://pub.dartlang.org"
+      sha256: ee1505df1426458f7f60aac270645098d318a8b4766d85fde75f76f2e21807d1
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
   xml:
     dependency: transitive
     description:
       name: xml
-      url: "https://pub.dartlang.org"
+      sha256: ac0e3f4bf00ba2708c33fbabbbe766300e509f8c82dbd4ab6525039813f7e2fb
+      url: "https://pub.dev"
     source: hosted
     version: "6.1.0"
   yaml:
     dependency: transitive
     description:
       name: yaml
-      url: "https://pub.dartlang.org"
+      sha256: "23812a9b125b48d4007117254bca50abb6c712352927eece9e155207b1db2370"
+      url: "https://pub.dev"
     source: hosted
     version: "3.1.1"
 sdks:


### PR DESCRIPTION
<!-- Feel free to use it and tweak some parts -->

#### Description
<!-- A general summary of your changes -->
Rewards can now be used to purchase "rewards" which are images with individual costs and titles. These images can be viewed in the new reward menu, which serves as a sort of wrapper for the old page. The old rewards page has been modified to not show the reward until it is purchased, and to display the cost of each reward. Upon purchasing a reward, it becomes visible in both the shop overlay and the gallery, and the cost is removed from your point total.

#### Screenshots (if appropriate):
<!-- Feel free to delete this if not used -->
<img width="254" alt="image" src="https://user-images.githubusercontent.com/114765511/233479933-82bffa3f-b3d2-4270-96d6-fb7038d5c521.png">

#### Types of Changes
<!-- Feel free to remove the ones you don't use, or remove all of them and explain what type of change it is -->
- New feature (non-breaking change which adds functionality)

#### Notes
<!-- Extra things you want to include -->
More rewards can be added by editing the file "rewards_database.dart", and should automatically appear. If not, the local storage may need to be purged by either reinstalling the app on your emulator or device or some other method. If adding more values causes problems, let me know and I will fix it.
Currently, all images are expected to be square. If this is not the case for some, they will be forcefully formatted as squares for uniformity.

#### Checklist
<!-- Some reminders -->
- [x] Moved the task in [Jira](https://jib-2329.atlassian.net/jira/software/projects/OM2329/boards/1) to 'In Review'
- [x] Updated the Incremental Release Notes
- [ ] Moved the task in [Jira](https://jib-2329.atlassian.net/jira/software/projects/OM2329/boards/1) to 'Done' once merged
