### PR TITLE
Clickable Listen Image

### DIFF
--- a/lib/Listen/Listen.dart
+++ b/lib/Listen/Listen.dart
@@ -47,7 +47,12 @@ class ListenScreenState extends State<ListenScreen> {
                   width: 5,
                 ),
               ),
-              child: Image.asset('assets/images/Beethoven.PNG'),
+              child: GestureDetector(
+                onTap: () {
+                  Navigator.pushNamed(context, '/beethoven');
+                },
+                child: Image.asset('assets/images/Beethoven.PNG'),
+              ),
             ),
             Padding(
               padding: const EdgeInsets.fromLTRB(60, 20, 60, 20),


### PR DESCRIPTION
#### Description
This PR allows the user to access the composer information page by clicking the image on the Listen screen, effectively resolving [OM2329-87](https://jib-2329.atlassian.net/browse/OM2329-87).

#### Screenshots (if appropriate):
This PR is referring to the composer image on the Listen screen, shown here:
![image](https://user-images.githubusercontent.com/63128403/233552383-e50aece4-1767-4e89-b296-483718aaf783.png)


#### Types of Changes
- New feature (non-breaking change which adds functionality)

#### Checklist
<!-- Some reminders -->
- [x] Moved the task in [Jira](https://jib-2329.atlassian.net/jira/software/projects/OM2329/boards/1) to 'In Review'
- [ ] Updated the Incremental Release Notes
- [ ] Moved the task in [Jira](https://jib-2329.atlassian.net/jira/software/projects/OM2329/boards/1) to 'Done' once merged
