### PR TITLE
ReviewScreen links to Quiz & Reward screens

### DIFF
--- a/lib/Quizzes/Results.dart
+++ b/lib/Quizzes/Results.dart
@@ -76,7 +76,7 @@ class ResultsScreen extends StatelessWidget {
         Navigator.of(context, rootNavigator: true).pushNamed("/quizzes");
       },
       child:
-          Text('Back to Quizzes', style: TextStyle(fontSize: 35, color: Colors.black)),
+          Text('Back to Quizzes', style: TextStyle(fontSize: 35,  color: Colors.black)),
     ));
 
     disp.add(OutlinedButton(
@@ -91,7 +91,7 @@ class ResultsScreen extends StatelessWidget {
         Navigator.of(context, rootNavigator: true).pushNamed("/rewardGallery");
       },
       child:
-          Text('Rewards Shop', style: TextStyle(fontSize: 35, color: Colors.black)),
+          Text('Rewards Shop', style: TextStyle(fontSize: 35,  color: Colors.black)),
     ));
     
 

--- a/lib/Quizzes/Results.dart
+++ b/lib/Quizzes/Results.dart
@@ -76,7 +76,7 @@ class ResultsScreen extends StatelessWidget {
         Navigator.of(context, rootNavigator: true).pushNamed("/quizzes");
       },
       child:
-          Text('Back to Quizzes', style: TextStyle(fontSize: 50, color: Colors.black)),
+          Text('Back to Quizzes', style: TextStyle(fontSize: 35, color: Colors.black)),
     ));
 
     disp.add(OutlinedButton(
@@ -91,7 +91,7 @@ class ResultsScreen extends StatelessWidget {
         Navigator.of(context, rootNavigator: true).pushNamed("/rewardGallery");
       },
       child:
-          Text('Rewards Shop', style: TextStyle(fontSize: 50, color: Colors.black)),
+          Text('Rewards Shop', style: TextStyle(fontSize: 35, color: Colors.black)),
     ));
     
 

--- a/lib/Quizzes/Results.dart
+++ b/lib/Quizzes/Results.dart
@@ -30,19 +30,19 @@ class ResultsScreen extends StatelessWidget {
 
     List<Widget> wrongQuestionsDisplay = [];
     for (int i = 0; i < wrongQuestions.length; i++) {
-      wrongQuestionsDisplay.add(
-          OutlinedButton(
-            style: OutlinedButton.styleFrom(
-              backgroundColor: Color.fromRGBO(255, 255, 255, 1.0),
-              foregroundColor: Color.fromRGBO(0, 0, 0, 1.0),
-              side: BorderSide(width: 5.0, color: Color.fromRGBO(194, 232, 139, 1.0)),
-              elevation: 5,
-              //fixedSize: Size:,
-            ),
-            onPressed: () => Navigator.pushNamed(context, '/main'),
-            child: Text(quiz.questionList[wrongQuestions[i]].question, style: TextStyle(fontSize: 20, color: Colors.black), textAlign: TextAlign.center)
-          )
-      );
+      wrongQuestionsDisplay.add(OutlinedButton(
+          style: OutlinedButton.styleFrom(
+            backgroundColor: Color.fromRGBO(255, 255, 255, 1.0),
+            foregroundColor: Color.fromRGBO(0, 0, 0, 1.0),
+            side: BorderSide(
+                width: 5.0, color: Color.fromRGBO(194, 232, 139, 1.0)),
+            elevation: 5,
+            //fixedSize: Size:,
+          ),
+          onPressed: () => Navigator.pushNamed(context, '/main'),
+          child: Text(quiz.questionList[wrongQuestions[i]].question,
+              style: TextStyle(fontSize: 20, color: Colors.black),
+              textAlign: TextAlign.center)));
       wrongQuestionsDisplay.add(SizedBox(height: 10));
     }
 
@@ -63,6 +63,37 @@ class ResultsScreen extends StatelessWidget {
     ];
 
     disp.addAll(wrongQuestionsDisplay);
+
+    disp.add(OutlinedButton(
+      style: OutlinedButton.styleFrom(
+        backgroundColor: Color.fromRGBO(255, 255, 255, 1.0),
+        foregroundColor: Color.fromRGBO(0, 0, 0, 1.0),
+        side: BorderSide(width: 5.0, color: Color.fromRGBO(194, 232, 139, 1.0)),
+        elevation: 5,
+        //fixedSize: Size:,
+      ),
+      onPressed: () {
+        Navigator.of(context, rootNavigator: true).pushNamed("/quizzes");
+      },
+      child:
+          Text('Back to Quizzes', style: TextStyle(fontSize: 50, color: Colors.black)),
+    ));
+
+    disp.add(OutlinedButton(
+      style: OutlinedButton.styleFrom(
+        backgroundColor: Color.fromRGBO(255, 255, 255, 1.0),
+        foregroundColor: Color.fromRGBO(0, 0, 0, 1.0),
+        side: BorderSide(width: 5.0, color: Color.fromRGBO(194, 232, 139, 1.0)),
+        elevation: 5,
+        //fixedSize: Size:,
+      ),
+      onPressed: () {
+        Navigator.of(context, rootNavigator: true).pushNamed("/rewardGallery");
+      },
+      child:
+          Text('Rewards Shop', style: TextStyle(fontSize: 50, color: Colors.black)),
+    ));
+    
 
     return WillPopScope(
         onWillPop: () async => false,


### PR DESCRIPTION
#### Description
Two buttons have been added to the Quiz results screen redirecting the user to the quizzes and reward screens respectively, effectively resolving [OM2329-89](https://jib-2329.atlassian.net/browse/OM2329-89).

#### Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/63128403/233558652-a5461c01-d2b9-4b89-b40e-472be505ef5f.png)

#### Types of Changes
- New feature (non-breaking change which adds functionality)

#### Checklist
- [x] Moved the task in [Jira](https://jib-2329.atlassian.net/jira/software/projects/OM2329/boards/1) to 'In Review'
- [ ] Updated the Incremental Release Notes
- [ ] Moved the task in [Jira](https://jib-2329.atlassian.net/jira/software/projects/OM2329/boards/1) to 'Done' once merged
