### PR TITLE
App bar consistency fix

### DIFF
--- a/lib/Composers/Bach.dart
+++ b/lib/Composers/Bach.dart
@@ -14,7 +14,11 @@ class BachScreen extends StatelessWidget {
     return Scaffold(
       backgroundColor: const Color.fromRGBO(255, 246, 167, 1),
       appBar: AppBar(
-        title: const Text('Bach'),
+        backgroundColor: Colors.transparent,
+        elevation: 0,
+        iconTheme: IconThemeData(
+          color: Colors.black,
+        ),
       ),
       body: SingleChildScrollView(
         child: Container(
@@ -22,6 +26,10 @@ class BachScreen extends StatelessWidget {
           child: Column(
             mainAxisSize: MainAxisSize.min,
             children: <Widget>[
+              const Text(
+                'Bach',
+                style: TextStyle(fontSize: 60),
+              ),
               Image.asset('assets/images/Bach.png'),
               const Text(
                 'Early Life',

--- a/lib/Composers/Beethoven.dart
+++ b/lib/Composers/Beethoven.dart
@@ -10,7 +10,11 @@ class BeethovenScreen extends StatelessWidget {
     return Scaffold(
       backgroundColor: const Color.fromRGBO(255, 246, 167, 1),
       appBar: AppBar(
-        title: const Text('Beethoven'),
+        backgroundColor: Colors.transparent,
+        elevation: 0,
+        iconTheme: IconThemeData(
+          color: Colors.black,
+        ),
       ),
       body: SingleChildScrollView(
         child: Container(
@@ -18,6 +22,10 @@ class BeethovenScreen extends StatelessWidget {
           child: Column(
             mainAxisSize: MainAxisSize.min,
             children: <Widget>[
+              const Text(
+                'Beethoven',
+                style: TextStyle(fontSize: 60),
+              ),
               Image.asset('assets/images/Beethoven.PNG'),
               const Text(
                 'Early Life',

--- a/lib/Composers/Mozart.dart
+++ b/lib/Composers/Mozart.dart
@@ -13,7 +13,11 @@ class MozartScreen extends StatelessWidget {
     return Scaffold(
       backgroundColor: const Color.fromRGBO(255, 246, 167, 1),
       appBar: AppBar(
-        title: const Text('Mozart'),
+        backgroundColor: Colors.transparent,
+        elevation: 0,
+        iconTheme: IconThemeData(
+          color: Colors.black,
+        ),
       ),
       body: SingleChildScrollView(
         child: Container(
@@ -21,6 +25,10 @@ class MozartScreen extends StatelessWidget {
           child: Column(
             mainAxisSize: MainAxisSize.min,
             children: <Widget>[
+              const Text(
+                'Mozart',
+                style: TextStyle(fontSize: 60),
+              ),
               Image.asset('assets/images/Mozart.png'),
               const Text(
                 'Early Life',

--- a/lib/Musical-Terms/Musical-Terms.dart
+++ b/lib/Musical-Terms/Musical-Terms.dart
@@ -38,10 +38,6 @@ class TermsScreenState extends State<TermsScreen> {
                 child: Column(
                   mainAxisSize: MainAxisSize.min,
                   children: <Widget>[
-                    const Align(
-                      alignment: Alignment.topLeft,
-                      child: BackButton(),
-                    ),
                     Center(
                       child: Column(
                         mainAxisSize: MainAxisSize.min,

--- a/lib/Musical-Works/Composition-Page.dart
+++ b/lib/Musical-Works/Composition-Page.dart
@@ -19,7 +19,11 @@ class CompScreen extends StatelessWidget {
     return Scaffold(
       backgroundColor: const Color.fromRGBO(196, 236, 249, 1),
       appBar: AppBar(
-        backgroundColor: Colors.blue.withOpacity(0),
+        backgroundColor: Colors.transparent,
+        elevation: 0,
+        iconTheme: IconThemeData(
+          color: Colors.black,
+        ),
       ),
       body: SingleChildScrollView(
         child: Column(children: <Widget>[

--- a/lib/settings/settings_menu.dart
+++ b/lib/settings/settings_menu.dart
@@ -22,7 +22,11 @@ class _SettingsScreenState extends State<SettingsScreen> {
     return Scaffold(
       backgroundColor: const Color.fromRGBO(255, 214, 153, 1),
       appBar: AppBar(
-        title: const Text('Settings'),
+        backgroundColor: Colors.transparent,
+        elevation: 0,
+        iconTheme: IconThemeData(
+          color: Colors.black,
+        ),
       ),
       body: Center(
         child: Column(


### PR DESCRIPTION
#### Description
This PR adds a consistent top left black back button to all remaining screens, so that every screen has a consistent top bar. This PR does so by rendering a transparent AppBar with a black back button for the screens shown below. The remaining screens are unchanged. This effectively resolves [OM2329-86](https://jib-2329.atlassian.net/browse/OM2329-86).

#### Screenshots (if appropriate):
![1](https://user-images.githubusercontent.com/63128403/233567403-ed6e197b-351a-44aa-95bd-73adc6d0cb57.PNG)
![2](https://user-images.githubusercontent.com/63128403/233567404-6ad87d59-5ceb-4e78-b721-97c85c1c7f0d.PNG)
![3](https://user-images.githubusercontent.com/63128403/233567407-cdb95d88-1948-445a-abc5-49b8d04efec2.PNG)
![4](https://user-images.githubusercontent.com/63128403/233567411-93452624-2fe1-4180-91e8-76ebba00cec8.PNG)
![5](https://user-images.githubusercontent.com/63128403/233567412-8a632024-d7fb-4f4e-9d19-6c1f71328110.PNG)
![6](https://user-images.githubusercontent.com/63128403/233567413-13538b23-9f5f-4b40-b8f5-63f23120beec.PNG)


#### Types of Changes
- New feature (non-breaking change which adds functionality)

#### Notes
The app bar is still rendered to prevent issues with padding, but is rendered transparently with the back button set to black for consistency. We can apply this solution to the already fixed screens, but given that both the current SafeArea solution and transparent AppBar solutions are functionally equivalent, such a rebase isn't necessary for the end-user and should be extremely low priority for any future sprints as it would only slightly aid the dev team.

#### Checklist
- [ ] Moved the task in [Jira](https://jib-2329.atlassian.net/jira/software/projects/OM2329/boards/1) to 'In Review'
- [ ] Updated the Incremental Release Notes
- [ ] Moved the task in [Jira](https://jib-2329.atlassian.net/jira/software/projects/OM2329/boards/1) to 'Done' once merged
