### PR TITLE
Song Name Update on ListenScreen

### DIFF
--- a/lib/Listen/Listen.dart
+++ b/lib/Listen/Listen.dart
@@ -50,26 +50,34 @@ class ListenScreenState extends State<ListenScreen> {
               child: Image.asset('assets/images/Beethoven.PNG'),
             ),
             Padding(
-              padding: const EdgeInsets.fromLTRB(60, 20, 60, 20),
-              child: OutlinedButton(
+                padding: const EdgeInsets.fromLTRB(60, 20, 60, 20),
+                child: OutlinedButton(
                   style: OutlinedButton.styleFrom(
                     backgroundColor: Color.fromRGBO(255, 255, 255, 1.0),
                     foregroundColor: Color.fromRGBO(0, 0, 0, 1.0),
-                    side: BorderSide(width: 5.0, color: Color.fromRGBO(142, 148, 219, 1.0)),
+                    side: BorderSide(
+                        width: 5.0, color: Color.fromRGBO(142, 148, 219, 1.0)),
                     elevation: 5,
                     //fixedSize: Size:,
                   ),
-                onPressed: () {
-                  Navigator.pushNamed(context, '/beethoven');
-                },
-                child: const Text('Ludwig van Beethoven', style: TextStyle(fontSize: 20, color: Colors.black)),
-              )
-            ),
-            Text(
-              openingState.getPlayer.sequenceState?.currentSource?.tag,
-              style: TextStyle(fontSize: 30, color: Colors.black),
-              textAlign: TextAlign.center,
-            ),
+                  onPressed: () {
+                    Navigator.pushNamed(context, '/beethoven');
+                  },
+                  child: const Text('Ludwig van Beethoven',
+                      style: TextStyle(fontSize: 20, color: Colors.black)),
+                )),
+            StreamBuilder<SequenceState?>(
+                stream: openingState.getPlayer.sequenceStateStream,
+                builder: (context, snapshot) {
+                  final state = snapshot.data;
+                  if (state?.sequence.isEmpty ?? true) {
+                    return const Text('');
+                  } else {
+                    return Text(state!.currentSource!.tag.toString(),
+                        style: TextStyle(fontSize: 30, color: Colors.black),
+                        textAlign: TextAlign.center);
+                  }
+                }),
             Padding(
               padding: const EdgeInsets.fromLTRB(60, 30, 60, 0),
               child: StreamBuilder<PositionData>(


### PR DESCRIPTION
#### Description
This PR allows the song name to dynamically update on the Listen screen based on the current state of the song player. This resolves [OM2329-88](https://jib-2329.atlassian.net/browse/OM2329-88).

#### Screenshots (if appropriate):
![1](https://user-images.githubusercontent.com/63128403/233573374-f62f7c30-8d63-4dfd-8de5-f8f273108dd6.PNG)
![2](https://user-images.githubusercontent.com/63128403/233573377-43725325-ba9d-4f3d-8d75-c8061343e9f3.PNG)
![3](https://user-images.githubusercontent.com/63128403/233573380-db303431-8189-46b2-819b-33bf9f2b72d2.PNG)
![4](https://user-images.githubusercontent.com/63128403/233573384-7ee81126-7e15-4263-88c6-1af9e15c4d5a.PNG)

#### Types of Changes
- New feature (non-breaking change which adds functionality)

#### Checklist
- [x] Moved the task in [Jira](https://jib-2329.atlassian.net/jira/software/projects/OM2329/boards/1) to 'In Review'
- [ ] Updated the Incremental Release Notes
- [ ] Moved the task in [Jira](https://jib-2329.atlassian.net/jira/software/projects/OM2329/boards/1) to 'Done' once merged
